### PR TITLE
Fix SQL views to match current parquet schemas

### DIFF
--- a/sql/020_base_parquet_views.sql
+++ b/sql/020_base_parquet_views.sql
@@ -9,7 +9,7 @@ create or replace view src_geo_samples as (
 );
 
 create or replace view src_geo_series_with_rnaseq_counts as (
-    select json_extract_string(accession,'accession') as accession
+    select accession
     from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series_with_rnaseq_counts.parquet')
 );
 

--- a/sql/030_staging_views.sql
+++ b/sql/030_staging_views.sql
@@ -1,16 +1,11 @@
--- Staging views: deduplicated, cleaned, and typed
+-- Staging views: cleaned, typed, and normalized
 --
--- The src_* views contain all snapshots (Full + Incrementals).
 -- These stg_* views:
---   1. Deduplicate to get the latest version of each record
---   2. Apply type corrections and coercions
---   3. Normalize column names (lowercase, consistent naming)
---   4. Drop internal columns (date, stage) not needed downstream
+--   1. Apply type corrections and coercions
+--   2. Normalize column names (lowercase, consistent naming)
+--   3. Enrich with accession-level statistics where needed
 --
--- Deduplication logic:
---   - PARTITION BY accession (unique identifier)
---   - ORDER BY date DESC, stage DESC (Incremental beats Full on same date)
---   - Take row_number = 1
+-- Note: The parquet files are already deduplicated by the ETL pipeline.
 
 -----
 -- SRA Staging Views
@@ -26,21 +21,13 @@ SELECT
     study_type,
     center_name,
     broker_name,
-    BioProject AS bioproject_accession,
-    GEO AS geo_accession,
+    bioproject AS bioproject_accession,
+    geo AS geo_accession,
     identifiers,
     attributes,
     xrefs,
     pubmed_ids
-FROM (
-    SELECT *,
-        ROW_NUMBER() OVER (
-            PARTITION BY accession
-            ORDER BY date DESC, stage DESC
-        ) as rn
-    FROM src_sra_studies
-)
-WHERE rn = 1;
+FROM src_sra_studies;
 
 CREATE OR REPLACE VIEW stg_sra_samples AS
 SELECT
@@ -50,27 +37,17 @@ SELECT
     organism,
     description,
     taxon_id,
-    geo AS geo_accession,
-    BioSample AS biosample_accession,
+    biosample AS biosample_accession,
     identifiers,
     attributes,
     xrefs
-FROM (
-    SELECT *,
-        ROW_NUMBER() OVER (
-            PARTITION BY accession
-            ORDER BY date DESC, stage DESC
-        ) as rn
-    FROM src_sra_samples
-)
-WHERE rn = 1;
+FROM src_sra_samples;
 
 CREATE OR REPLACE VIEW stg_sra_experiments AS
 SELECT
     accession,
     alias,
     title,
-    description,
     design,
     center_name,
     study_accession,
@@ -80,7 +57,6 @@ SELECT
     library_name,
     library_construction_protocol,
     library_layout,
-    library_layout_orientation,
     TRY_CAST(library_layout_length AS INTEGER) AS library_layout_length,
     TRY_CAST(library_layout_sdev AS DOUBLE) AS library_layout_sdev,
     library_strategy,
@@ -92,46 +68,24 @@ SELECT
     attributes,
     xrefs,
     reads
-FROM (
-    SELECT *,
-        ROW_NUMBER() OVER (
-            PARTITION BY accession
-            ORDER BY date DESC, stage DESC
-        ) as rn
-    FROM src_sra_experiments
-)
-WHERE rn = 1;
+FROM src_sra_experiments;
 
 CREATE OR REPLACE VIEW stg_sra_runs AS
 SELECT
-    accession,
-    alias,
-    experiment_accession,
-    title,
-    total_spots,
-    total_bases,
-    size AS size_bytes,
-    avg_length,
-    identifiers,
-    attributes,
-    files,
-    reads,
-    base_counts,
-    qualities,
-    tax_analysis
-FROM (
-    SELECT *,
-        ROW_NUMBER() OVER (
-            PARTITION BY accession
-            ORDER BY date DESC, stage DESC
-        ) as rn
-    FROM src_sra_runs
-)
-WHERE rn = 1;
+    r.accession,
+    r.alias,
+    r.experiment_accession,
+    r.title,
+    a.spots AS total_spots,
+    a.bases AS total_bases,
+    r.identifiers,
+    r.attributes,
+    r.qualities
+FROM src_sra_runs r
+LEFT JOIN src_sra_accessions a ON r.accession = a.accession;
 
 -----
 -- GEO Staging Views
--- Passthrough for now - add deduplication if needed
 -----
 
 CREATE OR REPLACE VIEW stg_geo_series AS
@@ -145,7 +99,6 @@ SELECT * FROM src_geo_platforms;
 
 -----
 -- Biosample/Bioproject Staging Views
--- Passthrough for consistency in naming convention
 -----
 
 CREATE OR REPLACE VIEW stg_biosamples AS
@@ -159,7 +112,7 @@ SELECT * FROM src_bioprojects;
 -----
 
 CREATE OR REPLACE VIEW stg_pubmed_articles AS
-SELECT
+SELECT DISTINCT ON (pmid)
     pmid,
     title,
     abstract,
@@ -177,19 +130,12 @@ SELECT
     pages,
     languages,
     vernacular_title,
+    other_id,
     authors,
     mesh_terms,
     publication_types,
     chemical_list,
     keywords,
-    references,
+    "references",
     grant_ids
-FROM (
-    SELECT *,
-        ROW_NUMBER() OVER (
-            PARTITION BY pmid
-            ORDER BY _inserted_at DESC
-        ) as rn
-    FROM src_pubmed_articles
-)
-WHERE rn = 1;
+FROM src_pubmed_articles;

--- a/sql/040_geometadb_views.sql
+++ b/sql/040_geometadb_views.sql
@@ -64,7 +64,6 @@ SELECT
     contact."name"."last" AS contact_last_name,
     contact."name"."first" || ' ' || contact."name"."last" AS contact,
     supplemental_files,
-    data_processing,
 
     -- Indicates if the GEO Series has associated ncbi-supplied RNA-Seq data
     CASE WHEN h.accession IS NOT NULL THEN TRUE ELSE FALSE END AS has_geo_computed_rnaseq
@@ -88,8 +87,7 @@ create or replace view gpl as (
     description,
     'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' || accession AS web_link,
     contact."name"."first" || ' ' || contact."name"."last" AS contact,
-    data_row_count,
-    summary
+    data_row_count
 FROM src_geo_platforms
 );
 

--- a/sql/050_sradb_views.sql
+++ b/sql/050_sradb_views.sql
@@ -134,7 +134,7 @@ SELECT
     NULL AS broker_name,
     NULL AS instrument_name,
     NULL AS run_date,
-    CAST(files AS VARCHAR) AS run_file,
+    NULL AS run_file,
     NULL AS run_center,
     NULL AS total_data_blocks,
     experiment_accession,


### PR DESCRIPTION
## Summary
- **Remove broken deduplication logic**: The `date` and `stage` columns used for `ROW_NUMBER()` deduplication no longer exist in the parquet files — the ETL pipeline now produces deduplicated output directly.
- **Fix missing/renamed columns across all 4 SQL files**: Removed references to 15+ columns that no longer exist in the parquet schemas (e.g., `library_layout_orientation`, `data_processing`, `_inserted_at`, `files`, `tax_analysis`).
- **Preserve run-level statistics**: Enriched `stg_sra_runs` with `spots`/`bases` from `sra_accessions` via LEFT JOIN, since these stats moved out of the `sra_runs` parquet file but are heavily used downstream in `sradb.sra` and `run_with_study`.

## Details

| File | Changes |
|------|---------|
| `020_base_parquet_views.sql` | Remove broken `json_extract_string()` on already-plain VARCHAR column |
| `030_staging_views.sql` | Remove dedup logic (4 views), fix missing columns, enrich runs with accession stats, add `other_id` to pubmed, quote reserved word `"references"` |
| `040_geometadb_views.sql` | Remove `data_processing` from gse, `summary` from gpl |
| `050_sradb_views.sql` | `CAST(files AS VARCHAR)` → `NULL AS run_file` |

## Test plan
- [x] All 4 SQL files execute successfully against live parquet endpoints
- [x] All views created: 11 src_, 10 stg_, 6 geometadb, 9 sradb
- [ ] Verify `build_db.py` produces a valid DuckDB file end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)