### PR TITLE
Fix SQL injection risk in DuckDB credential setup

### DIFF
--- a/packages/omicidx-etl/src/omicidx/etl/db.py
+++ b/packages/omicidx-etl/src/omicidx/etl/db.py
@@ -7,6 +7,11 @@ import duckdb
 from .config import settings
 
 
+def _q(value: str) -> str:
+    """Escape a string for safe use in a SQL single-quoted literal."""
+    return value.replace("'", "''")
+
+
 def duckdb_setup_sql(temp_directory: str | None = None):
     """
     Generate DuckDB setup SQL with optional custom temp directory.
@@ -28,14 +33,14 @@ def duckdb_setup_sql(temp_directory: str | None = None):
     LOAD httpfs;
     SET memory_limit='16GB';
     SET preserve_insertion_order=false;
-    SET temp_directory='{temp_directory}';
+    SET temp_directory='{_q(temp_directory)}';
     SET max_temp_directory_size='100GB';
     CREATE SECRET minio (
         TYPE S3,
-        KEY_ID '{settings.AWS_ACCESS_KEY_ID}',
-        SECRET '{settings.AWS_SECRET_ACCESS_KEY}',
-        ENDPOINT '{endpoint}',
-        URL_STYLE '{settings.AWS_URL_STYLE or "path"}',
+        KEY_ID '{_q(settings.AWS_ACCESS_KEY_ID)}',
+        SECRET '{_q(settings.AWS_SECRET_ACCESS_KEY)}',
+        ENDPOINT '{_q(endpoint)}',
+        URL_STYLE '{_q(settings.AWS_URL_STYLE or "path")}',
         USE_SSL 'true'
     );
     """

--- a/packages/omicidx-etl/src/omicidx/etl/sql/runner.py
+++ b/packages/omicidx-etl/src/omicidx/etl/sql/runner.py
@@ -23,6 +23,11 @@ from omicidx.etl.sql import get_sql, list_sql_files
 from ..log import logger
 
 
+def _q(value: str) -> str:
+    """Escape a string for safe use in a SQL single-quoted literal."""
+    return value.replace("'", "''")
+
+
 def get_connection() -> duckdb.DuckDBPyConnection:
     """Create a DuckDB connection with R2 credentials."""
     con = duckdb.connect()
@@ -37,9 +42,9 @@ def get_connection() -> duckdb.DuckDBPyConnection:
         sql = f"""
 create or replace secret r2 (
     TYPE r2,
-    KEY_ID '{aws_access_key_id}',
-    SECRET '{aws_secret_access_key}',
-    ACCOUNT_ID '{aws_endpoint_url}'
+    KEY_ID '{_q(aws_access_key_id)}',
+    SECRET '{_q(aws_secret_access_key)}',
+    ACCOUNT_ID '{_q(aws_endpoint_url)}'
 );"""
         con.execute(sql)
         logger.info("R2 secret created successfully")


### PR DESCRIPTION
Closes #19

## Summary
- Add `_q()` helper that escapes single quotes for SQL single-quoted literals
- Apply to all credential and path values in `db.py:duckdb_setup_sql()` and `runner.py:get_connection()`
- Both files used f-strings to embed credentials directly in `CREATE SECRET` DDL with no escaping

AWS credential strings don't currently contain single quotes, so this is low-severity in practice. But it's bad form and could cause silent failures or injection if credentials are ever rotated to values with special characters.

## Test plan
- [x] Ruff lint and format checks pass
- [x] `uv run pytest packages/ -q` → 23 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)