### PR TITLE
Fix BioProject parser: re.sub misuse and None crashes on missing XML elements

### DIFF
--- a/packages/omicidx-parsers/src/omicidx/parsers/biosample.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/biosample.py
@@ -178,14 +178,15 @@ def parse_bioproject_xml_element(element: Element) -> dict:
     d2["description"] = projtop.findtext("./Project/ProjectDescr/Description")
     d2["name"] = projtop.findtext("./Project/ProjectDescr/Name")
     archive_id = projtop.find("./Project/ProjectID/ArchiveID")
-    d2["accession"] = archive_id.attrib["accession"]  # type: ignore
+    d2["accession"] = archive_id.attrib["accession"] if archive_id is not None else None
     pubs = []
     for pub in projtop.findall(".//Publication"):
+        db_type = pub.findtext("./DbType") or ""
         pubs.append(
             {
                 "pubdate": pub.get("date", None),
                 "id": pub.get("id", None),
-                "db": re.sub("^e", "", pub.findtext("./DbType").replace("^e", "", 1)),  # type: ignore
+                "db": re.sub("^e", "", db_type),
             }
         )
     d2["publications"] = pubs


### PR DESCRIPTION
Closes #18

## Summary
Three bugs fixed in `parse_bioproject_xml_element()` in `biosample.py:188`:

1. **Double-replace bug**: `pub.findtext("./DbType").replace("^e", "", 1)` matched the *literal* string `^e` (not a regex), so it was always a no-op. The outer `re.sub("^e", "", ...)` already does the correct regex strip of a leading `e`. Removed the spurious `.replace()` call.

2. **None crash on missing `DbType`**: `findtext()` returns `None` when the element is absent. The old code would crash with `TypeError: expected string or bytes-like object`. Fixed with `or ""` default.

3. **None crash on missing `ArchiveID`**: `find("./Project/ProjectID/ArchiveID")` can return `None`. Old code accessed `.attrib["accession"]` unconditionally → `AttributeError`. Fixed with an explicit `None` check.

## Test plan
- [x] `uv run pytest packages/ -q` → 23 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)