### PR TITLE
fix(geo): deduplicate GEO accessions across date partitions

### DIFF
--- a/packages/omicidx-etl/src/omicidx/etl/sql/010_raw_to_parquet.sql
+++ b/packages/omicidx-etl/src/omicidx/etl/sql/010_raw_to_parquet.sql
@@ -33,6 +33,7 @@ copy (
         relation,
         trim(manufacture_protocol) as manufacture_protocol
     from read_ndjson_auto('r2://omicidx/geo/raw/gpl/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
     order by accession
 ) to 'r2://omicidx/geo/parquet/geo_platforms.parquet' (format parquet, compression zstd);
 
@@ -64,6 +65,7 @@ copy (
         trim(overall_design) as overall_design,
         contributor
     from read_ndjson_auto('r2://omicidx/geo/raw/gse/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
     order by accession
 ) to 'r2://omicidx/geo/parquet/geo_series.parquet' (format parquet, compression zstd);
 
@@ -96,6 +98,7 @@ copy (
         channels,
         contributor
     from read_ndjson_auto('r2://omicidx/geo/raw/gsm/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
     order by accession
 ) to 'r2://omicidx/geo/parquet/geo_samples.parquet' (format parquet, compression zstd);
 


### PR DESCRIPTION
## Summary

- GEO ETL writes records to date-partitioned paths (e.g. `gse/year=X/month=Y/`). When an accession is updated (pubmed_id added, status change, etc.), it appears in multiple monthly partitions.
- The consolidation SQL in `010_raw_to_parquet.sql` had no deduplication, so the resulting `geo_series.parquet`, `geo_samples.parquet`, and `geo_platforms.parquet` files contained duplicate rows for updated accessions.
- Adds `QUALIFY row_number() OVER (PARTITION BY accession ORDER BY last_update_date DESC NULLS LAST) = 1` to all three GEO copy statements, keeping only the most recent version of each accession.

Closes #5

## Test plan

- [ ] Verify `geo_series.parquet` row count drops (duplicates removed) after next ETL run
- [ ] Verify `SELECT count(*), count(DISTINCT accession) FROM geo_series` returns equal counts
- [ ] Verify `geo_samples.parquet` and `geo_platforms.parquet` likewise have no duplicate accessions