### PR TITLE
refactor(parsers): standardize on httpx, remove urllib/requests

### DIFF
--- a/packages/omicidx-parsers/pyproject.toml
+++ b/packages/omicidx-parsers/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
 ]
 keywords = ["genomics", "bioinformatics", "open data", "SRA", "GEO", "biosample"]
 dependencies = [
-    "requests>=2.22",
     "click",
     "tenacity>=8.0.1",
     "httpx",

--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
@@ -10,8 +10,7 @@ import collections
 import datetime
 import logging
 import re
-import urllib
-from io import StringIO
+from io import BytesIO, StringIO
 
 import httpx
 import omicidx.parsers.geo.pydantic_models as pydantic_models
@@ -130,8 +129,10 @@ def get_geo_accession_xml(accession, targ="all", view="brief"):
         stop=stop_after_attempt(10),
         reraise=True,
     )
-    def _fetch():
-        return urllib.request.urlopen(url)
+    def _fetch() -> BytesIO:
+        resp = httpx.get(url, timeout=120, follow_redirects=True)
+        resp.raise_for_status()
+        return BytesIO(resp.content)
 
     return _fetch()
 

--- a/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
@@ -17,11 +17,11 @@ import contextlib
 import gzip
 import logging
 import re
-import urllib
-import urllib.error
-import urllib.request
 import xml.etree.ElementTree as etree
 from collections import defaultdict
+from io import BytesIO
+
+import httpx
 
 from . import pydantic_models
 
@@ -31,7 +31,9 @@ logger = logging.getLogger(__name__)
 def parse_xml_url(url: str, entity: str, gz: bool = True):
     n = 0
 
-    with gzip.open(urllib.request.urlopen(url), "rb") as f:
+    resp = httpx.get(url, timeout=120, follow_redirects=True)
+    resp.raise_for_status()
+    with gzip.open(BytesIO(resp.content), "rb") as f:
         for event, element in etree.iterparse(f):
             if event == "end" and element.tag == entity:
                 rec = globals()["SRA" + entity.title() + "Record"](element).data

--- a/packages/omicidx-parsers/tests/geo/test_parser.py
+++ b/packages/omicidx-parsers/tests/geo/test_parser.py
@@ -1,5 +1,4 @@
-# these are just to test types
-import http
+import io
 
 import pydantic
 from omicidx.parsers.geo import parser
@@ -15,7 +14,7 @@ def test_entrez_instance():
 
 def test_get_geo_accession_xml():
     res = parser.get_geo_accession_xml(TEST_GSE)
-    assert isinstance(res, http.client.HTTPResponse)
+    assert isinstance(res, io.BytesIO)
     firstline = next(res)
     assert isinstance(firstline, bytes)
     assert firstline.decode("UTF-8").startswith("<?xml")

--- a/uv.lock
+++ b/uv.lock
@@ -2196,7 +2196,6 @@ dependencies = [
     { name = "httpx" },
     { name = "orjson" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "tenacity" },
     { name = "universal-pathlib" },
 ]
@@ -2218,7 +2217,6 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.9.2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
-    { name = "requests", specifier = ">=2.22" },
     { name = "tenacity", specifier = ">=8.0.1" },
     { name = "universal-pathlib" },
 ]


### PR DESCRIPTION
## Summary

- Replaces `urllib.request.urlopen` with `httpx.get` in `geo/parser.py` (`get_geo_accession_xml`) and `sra/parser.py` (`parse_xml_url`)
- Both callers now wrap `resp.content` in `io.BytesIO`, preserving the file-like interface expected by downstream code (`gzip.open`, iteration by line)
- Removes `requests>=2.22` from `omicidx-parsers` dependencies — it was declared but never imported anywhere in the source
- Updates the `test_get_geo_accession_xml` assertion to check for `io.BytesIO` instead of `http.client.HTTPResponse`

Closes #16

## Test plan

- [ ] CI lint + test passes
- [ ] `test_get_geo_accession_xml` passes with new `BytesIO` check
- [ ] `test_get_geo_accession_soft` still passes (unchanged code path)