### PR TITLE
style(parsers): add type hints and fix doc/naming issues

### DIFF
--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
@@ -222,7 +222,7 @@ def get_geo_entities(txt):
 #####################################
 
 
-def get_subseries_from_relations(relation_list):
+def get_subseries_from_relations(relation_list: list[str]) -> list[str]:
     ret = []
     for i in relation_list:
         if i.startswith("SuperSeries of:"):
@@ -230,7 +230,7 @@ def get_subseries_from_relations(relation_list):
     return ret
 
 
-def get_bioprojects_from_relations(relation_list):
+def get_bioprojects_from_relations(relation_list: list[str]) -> list[str]:
     ret = []
     for i in relation_list:
         if i.startswith("BioProject: https://www.ncbi.nlm.nih.gov/bioproject/"):
@@ -240,7 +240,7 @@ def get_bioprojects_from_relations(relation_list):
     return ret
 
 
-def get_SRA_from_relations(relation_list):
+def get_sra_from_relations(relation_list: list[str]) -> list[str]:
     ret = []
     for i in relation_list:
         if i.startswith("SRA: https://www.ncbi.nlm.nih.gov/sra?term="):
@@ -248,7 +248,7 @@ def get_SRA_from_relations(relation_list):
     return ret
 
 
-def get_biosample_from_relations(relation_list):
+def get_biosample_from_relations(relation_list: list[str]) -> list[str]:
     ret = []
     for i in relation_list:
         if i.startswith("BioSample: https://www.ncbi.nlm.nih.gov/biosample/"):
@@ -258,7 +258,7 @@ def get_biosample_from_relations(relation_list):
     return ret
 
 
-def get_channel_characteristics(d, ch):
+def get_channel_characteristics(d: dict, ch: int) -> dict:
     ch_items = [k for k in d if k.endswith(f"ch{ch}")]
     characteristics = []
     ret = {}
@@ -287,12 +287,12 @@ def get_channel_characteristics(d, ch):
     return ret
 
 
-def _split_geo_name(v):
+def _split_geo_name(v: str) -> dict[str, str]:
     """split name of form first,middle,last into dict"""
     return dict(zip(["first", "middle", "last"], v.split(","), strict=False))
 
 
-def _create_contact_from_parsed(d):
+def _create_contact_from_parsed(d: dict) -> dict:
     contact_dict = {}
     for k, v in d.items():
         if k.startswith("contact"):
@@ -312,7 +312,7 @@ def _create_contact_from_parsed(d):
     return contact_dict
 
 
-def _split_contributor_names(contribs):
+def _split_contributor_names(contribs: list[str]) -> list[dict]:
     if len(contribs) == 0:
         return []
     return [_split_geo_name(v) for v in contribs]
@@ -324,7 +324,7 @@ def _split_contributor_names(contribs):
 # GSE, GSM, or GPL specific parser and return #
 # appropriate class.                          #
 ###############################################
-def _parse_single_entity_soft(entity_txt):
+def _parse_single_entity_soft(entity_txt: list[str]):
     # Deal with common stuff first:
     tups = [_split_on_first_equal(line) for line in entity_txt]
     tups[0][1]
@@ -384,7 +384,7 @@ def _parse_single_entity_soft(entity_txt):
 ###############################################################################
 #        Update date fields of format 'month day year' to date type.          #
 ###############################################################################
-def _fix_date_fields(d):
+def _fix_date_fields(d: dict) -> dict:
     for datefield in ["submission_date", "last_update_date"]:
         if datefield in d:
             d[datefield] = datetime.datetime.strptime(d[datefield], "%b %d %Y")
@@ -398,7 +398,7 @@ def _parse_single_gse_soft(d2):
     try:
         d2["subseries"] = get_subseries_from_relations(d2["relation"])
         d2["bioprojects"] = get_bioprojects_from_relations(d2["relation"])
-        d2["sra_studies"] = get_SRA_from_relations(d2["relation"])
+        d2["sra_studies"] = get_sra_from_relations(d2["relation"])
         # GEO sometimes references SRS and SRR from series--filter those out
         d2["sra_studies"] = list(filter(lambda a: a.find("P") > 0, d2["sra_studies"]))
     except KeyError:
@@ -420,7 +420,7 @@ def _parse_single_gse_soft(d2):
     return pydantic_models.GEOSeries(**d2)
 
 
-def _create_gsm_channel_data(d):
+def _create_gsm_channel_data(d: dict) -> list[dict]:
     ch_count = int(d["channel_count"])
     ch_recs = []
     for i in range(0, ch_count):
@@ -460,7 +460,7 @@ def _parse_single_gsm_soft(d2):
             d2[k] = None
     try:
         d2["biosample"] = get_biosample_from_relations(d2["relation"])[0]
-        d2["sra_experiment"] = get_SRA_from_relations(d2["relation"])[0]
+        d2["sra_experiment"] = get_sra_from_relations(d2["relation"])[0]
     except (KeyError, IndexError):
         d2["biosample"] = None
         d2["sra_experiment"] = None

--- a/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
@@ -100,7 +100,7 @@ def parse_xml_file(xmlfilename):
     logger.info(f"parsed {n} entity entries")
 
 
-def parse_study(xml):
+def parse_study(xml: etree.Element) -> dict:
     """Parse an SRA xml STUDY element
 
     Parameters
@@ -148,7 +148,7 @@ def parse_study(xml):
     return d
 
 
-def parse_submission(xml):
+def parse_submission(xml: etree.Element) -> dict:
     """Parse an SRA xml SUBMISSION element
 
     Parameters
@@ -180,7 +180,7 @@ def model_from_single_xml(txt):
     return getattr(pydantic_models, "Sra" + entity.capitalize())(**et)
 
 
-def parse_run(xml):
+def parse_run(xml: etree.Element) -> dict:
     """Parse an SRA xml RUN element
 
     Parameters
@@ -218,7 +218,7 @@ def parse_run(xml):
     return d
 
 
-def _parse_run_stats(xml):
+def _parse_run_stats(xml: etree.Element | None) -> dict | None:
     if xml is None:
         return None
     stats = []
@@ -232,7 +232,7 @@ def _parse_run_stats(xml):
     return {"reads": stats}
 
 
-def _parse_run_bases(xml):
+def _parse_run_bases(xml: etree.Element | None) -> dict | None:
     if xml is None:
         return None
     ret = []
@@ -241,7 +241,7 @@ def _parse_run_bases(xml):
     return {"base_counts": ret}
 
 
-def _parse_run_files(xml):
+def _parse_run_files(xml: etree.Element | None) -> dict | None:
     if xml is None:
         return None
     files = xml.findall("./SRAFile")
@@ -260,7 +260,7 @@ def _parse_run_files(xml):
     return {"files": ret}
 
 
-def parse_experiment(xml):
+def parse_experiment(xml: etree.Element) -> dict:
     """Parse an SRA xml EXPERIMENT element
 
     Parameters
@@ -349,7 +349,7 @@ def parse_experiment(xml):
     return d
 
 
-def parse_sample(xml):
+def parse_sample(xml: etree.Element) -> dict:
     """Parse an SRA xml SAMPLE element
 
     Parameters
@@ -380,7 +380,7 @@ def parse_sample(xml):
     return d
 
 
-def _parse_run_reads(node):
+def _parse_run_reads(node: etree.Element | None) -> dict:
     """Parse reads from runs."""
     d = {}
     try:
@@ -409,7 +409,7 @@ def _parse_run_reads(node):
     return d
 
 
-def _parse_run_qualities(node):
+def _parse_run_qualities(node: etree.Element) -> dict:
     """Parse the quality stats, if available, from RUN"""
     d = {}
     d["qualities"] = []
@@ -423,7 +423,7 @@ def _parse_run_qualities(node):
     return d
 
 
-def _parse_taxon(node):
+def _parse_taxon(node: etree.Element | None) -> dict:
     """Parse taxonomy informaiton."""
 
     def crawl(node, d=None):
@@ -512,16 +512,16 @@ def _safe_add_text_element(d, key, elem):
         d[key] = txt.strip()
 
 
-def _parse_attributes(xml):
-    if xml is None:
-        return {}
-    """Add attributes to a record
+def _parse_attributes(xml: etree.Element | None) -> dict:
+    """Parse attributes from an SRA XML ATTRIBUTES element.
 
     Parameters
     ----------
-    xml: xml.etree.ElementTree.ElementTree.Element
+    xml: xml.etree.ElementTree.Element or None
         An xml element of level "EXPERIMENT|STUDY|RUN|SAMPLE_ATTRIBUTES"
     """
+    if xml is None:
+        return {}
     d = defaultdict(list)
     # Iterate over "XXX_ATTRIBUTES"
     for elem in xml:
@@ -537,12 +537,12 @@ def _parse_attributes(xml):
     return d
 
 
-def _parse_links(xml):
-    """Add attributes to a record
+def _parse_links(xml: etree.Element | None) -> dict:
+    """Parse xref links from an SRA XML LINKS element.
 
     Parameters
     ----------
-    xml: xml.etree.ElementTree.ElementTree.Element
+    xml: xml.etree.ElementTree.Element or None
         An xml element of level "EXPERIMENT|STUDY|RUN|SAMPLE_LINKS"
     """
     if xml is None:
@@ -601,7 +601,7 @@ def _get_special_ids(id_rec):
         return False
 
 
-def _parse_identifiers(xml, section):
+def _parse_identifiers(xml: etree.Element, section: str) -> dict:
     """Parse IDENTIFIERS section"""
 
     d = defaultdict(list)
@@ -625,7 +625,7 @@ def _parse_identifiers(xml, section):
     return d
 
 
-def _process_path_map(xml, path_map):
+def _process_path_map(xml: etree.Element, path_map: dict) -> dict:
     d = {}
     for k, v in path_map.items():
         try:
@@ -651,7 +651,7 @@ def _process_path_map(xml, path_map):
     return d
 
 
-def _parse_study_type(xml):
+def _parse_study_type(xml: etree.Element | None) -> dict:
     d = {}
     if xml is None:
         return d
@@ -662,7 +662,7 @@ def _parse_study_type(xml):
     return d
 
 
-def try_update(d, value):
+def try_update(d: dict, value) -> dict:
     try:
         d.update(value)
         return d


### PR DESCRIPTION
## Summary

**SRA parser (`sra/parser.py`):**
- Add `Element | None -> dict` annotations to all internal parse helpers: `_parse_attributes`, `_parse_links`, `_parse_identifiers`, `_parse_study_type`, `_parse_run_stats`, `_parse_run_bases`, `_parse_run_files`, `_parse_run_reads`, `_parse_run_qualities`, `_parse_taxon`, `_process_path_map`, `try_update`
- Add `Element -> dict` return types to `parse_study`, `parse_submission`, `parse_experiment`, `parse_sample`, `parse_run`
- Fix misplaced `_parse_attributes` docstring — it appeared *after* the `if xml is None: return {}` guard, making it unreachable as a docstring

**GEO parser (`geo/parser.py`):**
- Rename `get_SRA_from_relations` → `get_sra_from_relations` (snake_case consistency)
- Add `list[str] -> list[str]` annotations to all four relation-parsing helpers
- Add type hints to `get_channel_characteristics`, `_split_geo_name`, `_create_contact_from_parsed`, `_split_contributor_names`, `_parse_single_entity_soft`, `_fix_date_fields`, `_create_gsm_channel_data`

Closes #17

## Test plan

- [ ] CI lint + test passes (no behavioral change, style only)