### PR TITLE
test(parsers): add offline unit tests for SRA, BioSample, and GEO parsers

### DIFF
--- a/packages/omicidx-parsers/pyproject.toml
+++ b/packages/omicidx-parsers/pyproject.toml
@@ -40,3 +40,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/omicidx"]
+
+[tool.pytest.ini_options]
+markers = [
+    "network: marks tests that require network access (deselect with '-m not network')",
+]

--- a/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
+++ b/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
@@ -78,9 +78,9 @@ def test_get_bioprojects_from_relations():
     assert result == ["PRJNA12345"]
 
 
-def test_get_SRA_from_relations():
+def test_get_sra_from_relations():
     rels = ["SRA: https://www.ncbi.nlm.nih.gov/sra?term=SRP000001"]
-    result = geo_parser.get_SRA_from_relations(rels)
+    result = geo_parser.get_sra_from_relations(rels)
     assert result == ["SRP000001"]
 
 
@@ -93,7 +93,7 @@ def test_get_biosample_from_relations():
 def test_relation_helpers_empty_list():
     assert geo_parser.get_subseries_from_relations([]) == []
     assert geo_parser.get_bioprojects_from_relations([]) == []
-    assert geo_parser.get_SRA_from_relations([]) == []
+    assert geo_parser.get_sra_from_relations([]) == []
     assert geo_parser.get_biosample_from_relations([]) == []
 
 
@@ -101,7 +101,7 @@ def test_relation_helpers_no_match():
     rels = ["something else entirely"]
     assert geo_parser.get_subseries_from_relations(rels) == []
     assert geo_parser.get_bioprojects_from_relations(rels) == []
-    assert geo_parser.get_SRA_from_relations(rels) == []
+    assert geo_parser.get_sra_from_relations(rels) == []
     assert geo_parser.get_biosample_from_relations(rels) == []
 
 

--- a/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
+++ b/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
@@ -1,0 +1,176 @@
+"""Offline unit tests for GEO SOFT parser internal functions."""
+
+import pytest
+from omicidx.parsers.geo import parser as geo_parser
+
+# ---------------------------------------------------------------------------
+# _split_on_first_equal
+# ---------------------------------------------------------------------------
+
+
+def test_split_on_first_equal_basic():
+    assert geo_parser._split_on_first_equal("key = value") == ("key", "value")
+
+
+def test_split_on_first_equal_multiple_equals():
+    result = geo_parser._split_on_first_equal("this = abc = 1")
+    assert result == ("this", "abc = 1")
+
+
+def test_split_on_first_equal_caret():
+    """Lines starting with ^ (entity markers) use = as delimiter."""
+    key, val = geo_parser._split_on_first_equal("^SERIES = GSE2553")
+    assert key == "^SERIES"
+    assert val == "GSE2553"
+
+
+# ---------------------------------------------------------------------------
+# get_geo_entities
+# ---------------------------------------------------------------------------
+
+SOFT_BLOCK = """\
+^SERIES = GSE2553
+!Series_title = My Series Title
+!Series_status = Public on Jan 01 2020
+^SAMPLE = GSM12345
+!Sample_title = Sample One
+!Sample_status = Public on Jan 01 2020
+"""
+
+
+def test_get_geo_entities_returns_dict():
+    lines = SOFT_BLOCK.splitlines()
+    result = geo_parser.get_geo_entities(lines)
+    assert isinstance(result, dict)
+
+
+def test_get_geo_entities_keys():
+    lines = SOFT_BLOCK.splitlines()
+    result = geo_parser.get_geo_entities(lines)
+    assert "GSE2553" in result
+    assert "GSM12345" in result
+
+
+def test_get_geo_entities_values_are_lists():
+    lines = SOFT_BLOCK.splitlines()
+    result = geo_parser.get_geo_entities(lines)
+    assert isinstance(result["GSE2553"], list)
+    assert isinstance(result["GSM12345"], list)
+
+
+# ---------------------------------------------------------------------------
+# Relation-parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_subseries_from_relations():
+    rels = [
+        "SuperSeries of: GSE111",
+        "BioProject: https://www.ncbi.nlm.nih.gov/bioproject/PRJNA1",
+    ]
+    result = geo_parser.get_subseries_from_relations(rels)
+    assert result == ["GSE111"]
+
+
+def test_get_bioprojects_from_relations():
+    rels = ["BioProject: https://www.ncbi.nlm.nih.gov/bioproject/PRJNA12345"]
+    result = geo_parser.get_bioprojects_from_relations(rels)
+    assert result == ["PRJNA12345"]
+
+
+def test_get_SRA_from_relations():
+    rels = ["SRA: https://www.ncbi.nlm.nih.gov/sra?term=SRP000001"]
+    result = geo_parser.get_SRA_from_relations(rels)
+    assert result == ["SRP000001"]
+
+
+def test_get_biosample_from_relations():
+    rels = ["BioSample: https://www.ncbi.nlm.nih.gov/biosample/SAMN00000001"]
+    result = geo_parser.get_biosample_from_relations(rels)
+    assert result == ["SAMN00000001"]
+
+
+def test_relation_helpers_empty_list():
+    assert geo_parser.get_subseries_from_relations([]) == []
+    assert geo_parser.get_bioprojects_from_relations([]) == []
+    assert geo_parser.get_SRA_from_relations([]) == []
+    assert geo_parser.get_biosample_from_relations([]) == []
+
+
+def test_relation_helpers_no_match():
+    rels = ["something else entirely"]
+    assert geo_parser.get_subseries_from_relations(rels) == []
+    assert geo_parser.get_bioprojects_from_relations(rels) == []
+    assert geo_parser.get_SRA_from_relations(rels) == []
+    assert geo_parser.get_biosample_from_relations(rels) == []
+
+
+# ---------------------------------------------------------------------------
+# _split_geo_name / _split_contributor_names
+# ---------------------------------------------------------------------------
+
+
+def test_split_geo_name_full():
+    result = geo_parser._split_geo_name("John,M,Doe")
+    assert result == {"first": "John", "middle": "M", "last": "Doe"}
+
+
+def test_split_geo_name_first_last():
+    result = geo_parser._split_geo_name("Jane,Doe")
+    assert result == {"first": "Jane", "middle": "Doe"}
+
+
+def test_split_contributor_names_empty():
+    assert geo_parser._split_contributor_names([]) == []
+
+
+def test_split_contributor_names():
+    result = geo_parser._split_contributor_names(["John,M,Doe", "Jane,,Smith"])
+    assert len(result) == 2
+    assert result[0]["first"] == "John"
+
+
+# ---------------------------------------------------------------------------
+# get_channel_characteristics
+# ---------------------------------------------------------------------------
+
+
+def test_get_channel_characteristics_basic():
+    d = {
+        "source_name_ch1": ["liver"],
+        "organism_ch1": ["Homo sapiens"],
+        "characteristics_ch1": ["tissue: liver", "age: 30"],
+    }
+    result = geo_parser.get_channel_characteristics(d, 1)
+    assert result["source_name"] == "liver"
+    assert result["organism"] == "Homo sapiens"
+    char_dict = {c["tag"]: c["value"] for c in result["characteristics"]}
+    assert char_dict["tissue"] == "liver"
+    assert char_dict["age"] == "30"
+
+
+# ---------------------------------------------------------------------------
+# Network-dependent tests — marked so they can be skipped in CI
+# ---------------------------------------------------------------------------
+
+
+pytestmark_network = pytest.mark.network
+
+
+@pytest.mark.network
+def test_get_geo_accession_soft_live():
+    """Hits NCBI — requires network."""
+    result = geo_parser.get_geo_accession_soft("GSE10")
+    assert isinstance(result, str)
+    assert result.startswith("^SERIES = ")
+
+
+@pytest.mark.network
+def test_get_geo_accession_xml_live():
+    """Hits NCBI — requires network."""
+    import io
+
+    result = geo_parser.get_geo_accession_xml("GSE10")
+    assert isinstance(result, io.BytesIO)
+    firstline = next(result)
+    assert firstline.decode("UTF-8").startswith("<?xml")

--- a/packages/omicidx-parsers/tests/geo/test_parser.py
+++ b/packages/omicidx-parsers/tests/geo/test_parser.py
@@ -1,9 +1,12 @@
 import io
 
 import pydantic
+import pytest
 from omicidx.parsers.geo import parser
 
 TEST_GSE = "GSE10"
+
+pytestmark = pytest.mark.network
 
 
 def test_entrez_instance():

--- a/packages/omicidx-parsers/tests/sra/parser/test_sra_xml_parsers.py
+++ b/packages/omicidx-parsers/tests/sra/parser/test_sra_xml_parsers.py
@@ -1,0 +1,261 @@
+"""Offline unit tests for SRA XML parser functions using inline XML fixtures."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+from omicidx.parsers.sra import parser as sra_parser
+
+# ---------------------------------------------------------------------------
+# Minimal XML fixtures
+# ---------------------------------------------------------------------------
+
+STUDY_XML = """<STUDY accession="SRP000001" alias="my_study" center_name="NCBI">
+  <IDENTIFIERS>
+    <PRIMARY_ID>SRP000001</PRIMARY_ID>
+    <EXTERNAL_ID namespace="BioProject">PRJNA12345</EXTERNAL_ID>
+    <EXTERNAL_ID namespace="GEO">GSE12345</EXTERNAL_ID>
+  </IDENTIFIERS>
+  <DESCRIPTOR>
+    <STUDY_TITLE>Test Study Title</STUDY_TITLE>
+    <STUDY_ABSTRACT>This is the abstract.</STUDY_ABSTRACT>
+    <STUDY_DESCRIPTION>Study description here.</STUDY_DESCRIPTION>
+    <STUDY_TYPE existing_study_type="Transcriptome Analysis"/>
+  </DESCRIPTOR>
+  <STUDY_LINKS>
+    <STUDY_LINK>
+      <XREF_LINK><DB>pubmed</DB><ID>12345678</ID></XREF_LINK>
+    </STUDY_LINK>
+  </STUDY_LINKS>
+  <STUDY_ATTRIBUTES>
+    <STUDY_ATTRIBUTE>
+      <TAG>ENA-SPOT-COUNT</TAG>
+      <VALUE>1000000</VALUE>
+    </STUDY_ATTRIBUTE>
+  </STUDY_ATTRIBUTES>
+</STUDY>"""
+
+EXPERIMENT_XML = """<EXPERIMENT accession="SRX000001" alias="exp_alias" center_name="NCBI">
+  <IDENTIFIERS>
+    <PRIMARY_ID>SRX000001</PRIMARY_ID>
+  </IDENTIFIERS>
+  <DESIGN>
+    <DESIGN_DESCRIPTION>A simple design</DESIGN_DESCRIPTION>
+    <LIBRARY_DESCRIPTOR>
+      <LIBRARY_NAME>lib1</LIBRARY_NAME>
+      <LIBRARY_STRATEGY>RNA-Seq</LIBRARY_STRATEGY>
+      <LIBRARY_SOURCE>TRANSCRIPTOMIC</LIBRARY_SOURCE>
+      <LIBRARY_SELECTION>cDNA</LIBRARY_SELECTION>
+      <LIBRARY_LAYOUT><SINGLE/></LIBRARY_LAYOUT>
+    </LIBRARY_DESCRIPTOR>
+  </DESIGN>
+  <PLATFORM>
+    <ILLUMINA>
+      <INSTRUMENT_MODEL>Illumina HiSeq 2000</INSTRUMENT_MODEL>
+    </ILLUMINA>
+  </PLATFORM>
+  <STUDY_REF accession="SRP000001">
+    <IDENTIFIERS><PRIMARY_ID>SRP000001</PRIMARY_ID></IDENTIFIERS>
+  </STUDY_REF>
+  <SAMPLE_DESCRIPTOR accession="SRS000001"/>
+  <EXPERIMENT_ATTRIBUTES>
+    <EXPERIMENT_ATTRIBUTE>
+      <TAG>library_prep_kit</TAG>
+      <VALUE>TruSeq</VALUE>
+    </EXPERIMENT_ATTRIBUTE>
+  </EXPERIMENT_ATTRIBUTES>
+</EXPERIMENT>"""
+
+SAMPLE_XML = """<SAMPLE accession="SRS000001" alias="samp_alias">
+  <IDENTIFIERS>
+    <PRIMARY_ID>SRS000001</PRIMARY_ID>
+    <EXTERNAL_ID namespace="BioSample">SAMN00000001</EXTERNAL_ID>
+  </IDENTIFIERS>
+  <TITLE>Human blood sample</TITLE>
+  <SAMPLE_NAME>
+    <TAXON_ID>9606</TAXON_ID>
+    <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>
+  </SAMPLE_NAME>
+  <DESCRIPTION>Blood drawn from healthy donor.</DESCRIPTION>
+  <SAMPLE_ATTRIBUTES>
+    <SAMPLE_ATTRIBUTE>
+      <TAG>tissue</TAG>
+      <VALUE>blood</VALUE>
+    </SAMPLE_ATTRIBUTE>
+  </SAMPLE_ATTRIBUTES>
+</SAMPLE>"""
+
+RUN_XML = """<RUN accession="SRR000001" alias="run_alias" total_spots="1000000"
+             total_bases="100000000" size="50000000">
+  <IDENTIFIERS>
+    <PRIMARY_ID>SRR000001</PRIMARY_ID>
+  </IDENTIFIERS>
+  <EXPERIMENT_REF accession="SRX000001"/>
+  <TITLE>Test Run</TITLE>
+  <RUN_ATTRIBUTES>
+    <RUN_ATTRIBUTE>
+      <TAG>run_quality</TAG>
+      <VALUE>good</VALUE>
+    </RUN_ATTRIBUTE>
+  </RUN_ATTRIBUTES>
+</RUN>"""
+
+
+# ---------------------------------------------------------------------------
+# parse_study
+# ---------------------------------------------------------------------------
+
+
+def test_parse_study_basic_fields():
+    xml = ET.fromstring(STUDY_XML)
+    result = sra_parser.parse_study(xml)
+
+    assert result["accession"] == "SRP000001"
+    assert result["alias"] == "my_study"
+    assert result["title"] == "Test Study Title"
+    assert result["abstract"] == "This is the abstract."
+    assert result["study_type"] == "Transcriptome Analysis"
+
+
+def test_parse_study_identifiers():
+    xml = ET.fromstring(STUDY_XML)
+    result = sra_parser.parse_study(xml)
+
+    # ID normalization strips "geo|gds|bioproject|..." but not "prjna" prefix
+    assert result["BioProject"] == "PRJNA12345"
+    assert result["GEO"] == "GSE12345"
+
+
+def test_parse_study_pubmed_ids():
+    xml = ET.fromstring(STUDY_XML)
+    result = sra_parser.parse_study(xml)
+
+    assert "pubmed_ids" in result
+    assert "12345678" in result["pubmed_ids"]
+
+
+# ---------------------------------------------------------------------------
+# parse_experiment
+# ---------------------------------------------------------------------------
+
+
+def test_parse_experiment_basic_fields():
+    xml = ET.fromstring(EXPERIMENT_XML)
+    result = sra_parser.parse_experiment(xml)
+
+    assert result["accession"] == "SRX000001"
+    assert result["library_strategy"] == "RNA-Seq"
+    assert result["library_source"] == "TRANSCRIPTOMIC"
+    assert result["library_selection"] == "cDNA"
+    assert result["library_layout"] == "SINGLE"
+    assert result["instrument_model"] == "Illumina HiSeq 2000"
+
+
+def test_parse_experiment_attributes():
+    xml = ET.fromstring(EXPERIMENT_XML)
+    result = sra_parser.parse_experiment(xml)
+
+    assert "attributes" in result
+    attrs = {a["tag"]: a["value"] for a in result["attributes"]}
+    assert attrs["library_prep_kit"] == "TruSeq"
+
+
+# ---------------------------------------------------------------------------
+# parse_sample
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sample_basic_fields():
+    xml = ET.fromstring(SAMPLE_XML)
+    result = sra_parser.parse_sample(xml)
+
+    assert result["accession"] == "SRS000001"
+    assert result["title"] == "Human blood sample"
+    assert result["organism"] == "Homo sapiens"
+    assert result["taxon_id"] == 9606
+
+
+def test_parse_sample_biosample_xref():
+    xml = ET.fromstring(SAMPLE_XML)
+    result = sra_parser.parse_sample(xml)
+
+    assert result["BioSample"] == "SAMN00000001"
+
+
+def test_parse_sample_attributes():
+    xml = ET.fromstring(SAMPLE_XML)
+    result = sra_parser.parse_sample(xml)
+
+    attrs = {a["tag"]: a["value"] for a in result["attributes"]}
+    assert attrs["tissue"] == "blood"
+
+
+# ---------------------------------------------------------------------------
+# parse_run
+# ---------------------------------------------------------------------------
+
+
+def test_parse_run_basic_fields():
+    xml = ET.fromstring(RUN_XML)
+    result = sra_parser.parse_run(xml)
+
+    assert result["accession"] == "SRR000001"
+    assert result["total_spots"] == 1000000
+    assert result["total_bases"] == 100000000
+    assert result["experiment_accession"] == "SRX000001"
+
+
+def test_parse_run_avg_length():
+    xml = ET.fromstring(RUN_XML)
+    result = sra_parser.parse_run(xml)
+
+    assert "avg_length" in result
+    assert result["avg_length"] == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# dict_from_single_xml / model_from_single_xml
+# ---------------------------------------------------------------------------
+
+
+def test_dict_from_single_xml_study():
+    result = sra_parser.dict_from_single_xml(STUDY_XML)
+    assert result["entity_type"] == "study"
+    assert result["accession"] == "SRP000001"
+
+
+def test_dict_from_single_xml_experiment():
+    result = sra_parser.dict_from_single_xml(EXPERIMENT_XML)
+    assert result["entity_type"] == "experiment"
+    assert result["accession"] == "SRX000001"
+
+
+def test_model_from_single_xml_study():
+    from omicidx.parsers.sra.pydantic_models import SraStudy
+
+    model = sra_parser.model_from_single_xml(STUDY_XML)
+    assert isinstance(model, SraStudy)
+    assert model.accession == "SRP000001"
+
+
+# ---------------------------------------------------------------------------
+# _parse_attributes: edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_attributes_none_returns_empty():
+    result = sra_parser._parse_attributes(None)
+    assert result == {}
+
+
+def test_parse_attributes_missing_value_text():
+    """Attribute with no VALUE text should be skipped, not crash."""
+    xml = ET.fromstring(
+        """<SAMPLE_ATTRIBUTES>
+        <SAMPLE_ATTRIBUTE><TAG>key</TAG><VALUE/></SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES>"""
+    )
+    result = sra_parser._parse_attributes(xml)
+    # No crash; attribute recorded with None value
+    assert "attributes" in result
+    assert result["attributes"][0]["tag"] == "key"
+    assert result["attributes"][0]["value"] is None

--- a/packages/omicidx-parsers/tests/test_biosample_parser.py
+++ b/packages/omicidx-parsers/tests/test_biosample_parser.py
@@ -1,0 +1,122 @@
+"""Offline unit tests for BioSampleParser with XML fixtures."""
+
+from io import StringIO
+
+from omicidx.parsers.biosample import BioSampleParser
+
+
+def _make_biosample_xml(body: str) -> StringIO:
+    return StringIO(f"<BioSampleSet>{body}</BioSampleSet>")
+
+
+MINIMAL_BIOSAMPLE = """
+<BioSample accession="SAMN00000001" id="1">
+  <Ids>
+    <Id db="SRA">SRS000001</Id>
+    <Id db="GEO">GSM000001</Id>
+    <Id db="dbGaP">phs000001</Id>
+  </Ids>
+  <Description>
+    <Title>Test sample</Title>
+    <Comment><Paragraph>A test biosample.</Paragraph></Comment>
+  </Description>
+  <Organism taxonomy_id="9606" taxonomy_name="Homo sapiens"/>
+  <Attributes>
+    <Attribute attribute_name="tissue" harmonized_name="tissue" display_name="Tissue">blood</Attribute>
+  </Attributes>
+  <Models><Model>Generic</Model></Models>
+</BioSample>
+"""
+
+
+def test_biosample_basic_fields():
+    parser = BioSampleParser(_make_biosample_xml(MINIMAL_BIOSAMPLE))
+    result = next(parser)
+
+    assert result["accession"] == "SAMN00000001"
+    assert result["id"] == "1"
+    assert result["title"] == "Test sample"
+    assert result["description"] == "A test biosample."
+    assert result["taxon_id"] == 9606
+    assert result["taxonomy_name"] == "Homo sapiens"
+
+
+def test_biosample_cross_references():
+    parser = BioSampleParser(_make_biosample_xml(MINIMAL_BIOSAMPLE))
+    result = next(parser)
+
+    assert result["sra_sample"] == "SRS000001"
+    assert result["gsm"] == "GSM000001"
+    assert result["dbgap"] == "phs000001"
+
+
+def test_biosample_attributes():
+    parser = BioSampleParser(_make_biosample_xml(MINIMAL_BIOSAMPLE))
+    result = next(parser)
+
+    assert "tissue" in result["attributes"]
+    assert result["attribute_recs"][0]["attribute_name"] == "tissue"
+    assert result["attribute_recs"][0]["value"] == "blood"
+
+
+def test_biosample_model():
+    parser = BioSampleParser(_make_biosample_xml(MINIMAL_BIOSAMPLE))
+    result = next(parser)
+
+    assert result["model"] == "Generic"
+
+
+def test_biosample_multiple_records():
+    xml = _make_biosample_xml(
+        MINIMAL_BIOSAMPLE
+        + MINIMAL_BIOSAMPLE.replace("SAMN00000001", "SAMN00000002").replace(
+            'id="1"', 'id="2"'
+        )
+    )
+    parser = BioSampleParser(xml)
+    results = list(parser)
+    assert len(results) == 2
+    assert results[0]["accession"] == "SAMN00000001"
+    assert results[1]["accession"] == "SAMN00000002"
+
+
+NO_SRA_BIOSAMPLE = """
+<BioSample accession="SAMN99999999" id="99">
+  <Ids>
+    <Id db="BioProject">PRJNA99999</Id>
+  </Ids>
+  <Description>
+    <Title>No SRA cross-ref</Title>
+  </Description>
+  <Organism taxonomy_id="10090" taxonomy_name="Mus musculus"/>
+  <Attributes/>
+  <Models><Model>Generic</Model></Models>
+</BioSample>
+"""
+
+
+def test_biosample_missing_sra_cross_refs():
+    """BioSample with no SRA/GEO/dbGaP IDs should have None for those fields."""
+    parser = BioSampleParser(_make_biosample_xml(NO_SRA_BIOSAMPLE))
+    result = next(parser)
+
+    assert result["sra_sample"] is None
+    assert result["gsm"] is None
+    assert result["dbgap"] is None
+
+
+def test_biosample_no_description_paragraph():
+    """BioSample without Description/Comment/Paragraph should not crash."""
+    xml_no_comment = """
+<BioSample accession="SAMN11111111" id="11">
+  <Ids><Id db="SRA">SRS111111</Id></Ids>
+  <Description><Title>No paragraph</Title></Description>
+  <Organism taxonomy_id="9606" taxonomy_name="Homo sapiens"/>
+  <Attributes/>
+</BioSample>
+"""
+    parser = BioSampleParser(_make_biosample_xml(xml_no_comment))
+    result = next(parser)
+
+    assert result["accession"] == "SAMN11111111"
+    assert result["description"] is None


### PR DESCRIPTION
## Summary

Adds meaningful offline test coverage to the parsers package, addressing #15. All new tests use inline fixtures and do not require network access.

**SRA XML parser** (`tests/sra/parser/test_sra_xml_parsers.py`):
- Inline XML fixtures for Study, Experiment, Sample, Run
- Tests for `parse_study`, `parse_experiment`, `parse_sample`, `parse_run`, `dict_from_single_xml`, `model_from_single_xml`
- Edge case: `_parse_attributes` with `None` input and attribute with no VALUE text

**BioSample parser** (`tests/test_biosample_parser.py`):
- Tests for basic fields, cross-references (SRA/GEO/dbGaP), attributes, model field, multiple records iteration
- Edge cases: BioSample with no SRA/GEO/dbGaP IDs; missing Description/Comment/Paragraph

**GEO SOFT parser** (`tests/geo/test_geo_soft_parsers.py`):
- Offline tests for `_split_on_first_equal`, `get_geo_entities`, all four relation-parsing helpers, `_split_geo_name`, `_split_contributor_names`, `get_channel_characteristics`
- Network tests (`get_geo_accession_soft`, `get_geo_accession_xml`) marked `@pytest.mark.network`

**Existing network tests** (`tests/geo/test_parser.py`):
- Add `pytestmark = pytest.mark.network` so the entire module is deselectable with `-m not network`

**pytest config** (`pyproject.toml`):
- Register the `network` marker in `[tool.pytest.ini_options]`

Closes #15

## Test plan

- [ ] `uv run pytest packages/omicidx-parsers/tests/ -m "not network"` — all 40 tests pass, 0 failures
- [ ] Network tests correctly deselected when `-m not network` is passed