### PR TITLE
fix(parsers): critical bug fixes from Opus code review

### DIFF
--- a/packages/omicidx-parsers/src/omicidx/parsers/biosample.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/biosample.py
@@ -2,11 +2,10 @@
 
 Implemented as an iterator
 
-
 >>> import omicidx.parsers.biosample as b
 >>> for bios in b.BioSampleParser(gzip.open('biosample_set.xml.gz', 'rb')):
->>>     print(bios.json())
->>>     print(bios.dict())
+...     print(bios.model_dump_json())
+...     print(bios.model_dump())
 """
 
 import datetime
@@ -19,38 +18,39 @@ import pydantic
 
 
 class IdRecs(pydantic.BaseModel):
-    db: str | None
-    label: str | None
-    id: str | None
+    db: str | None = None
+    label: str | None = None
+    id: str | None = None
 
 
 class AttrRecs(pydantic.BaseModel):
-    attribute_name: str | None
-    display_name: str | None
-    harmonized_name: str | None
-    value: str | None
-    unit: str | None
+    attribute_name: str | None = None
+    display_name: str | None = None
+    harmonized_name: str | None = None
+    value: str | None = None
+    unit: str | None = None
 
 
 class BioSample(pydantic.BaseModel):
     accession: str
     id: str
-    title: str | None
-    description: str | None
-    taxonomy_name: str
-    taxon_id: int
-    attribute_recs: list[AttrRecs]
-    attributes: list[str]
-    model: str | None
-    id_recs: list[IdRecs]
-    ids: list[str]
-    sra_sample: str | None
-    dbgap: str | None
-    gsm: str | None
-    publication_date: datetime.datetime | None
-    last_update: datetime.datetime | None
-    submission_date: datetime.datetime | None
-    access: str | None
+    title: str | None = None
+    description: str | None = None
+    taxonomy_name: str | None = None
+    taxon_id: int | None = None
+    attribute_recs: list[AttrRecs] = []
+    attributes: list[str] = []
+    model: str | None = None
+    id_recs: list[IdRecs] = []
+    ids: list[str] = []
+    sra_sample: str | None = None
+    dbgap: str | None = None
+    gsm: str | None = None
+    publication_date: datetime.datetime | None = None
+    last_update: datetime.datetime | None = None
+    submission_date: datetime.datetime | None = None
+    access: str | None = None
+    is_reference: str | None = None
 
 
 class SimplePublication(pydantic.BaseModel):
@@ -73,13 +73,13 @@ class LocusTag(pydantic.BaseModel):
 
 class BioProject(pydantic.BaseModel):
     data_types: list[str] = []
-    description: str | None
+    description: str | None = None
     accession: str
-    name: str | None
+    name: str | None = None
     publications: list[SimplePublication] = []
-    title: str | None
+    title: str | None = None
     external_links: list[ExternalLink] = []
-    release_date: str | None
+    release_date: str | None = None
     locus_tags: list[LocusTag] = []
 
 
@@ -136,12 +136,16 @@ class BioSampleParser:
                 bios["title"] = elem.findtext(".//Description/Title")
                 bios["description"] = elem.findtext(".//Description/Comment/Paragraph")
                 organism = elem.find(".//Organism")
-                bios["taxonomy_name"] = organism.get("taxonomy_name")
-                bios["taxon_id"] = int(organism.get("taxonomy_id"))
+                bios["taxonomy_name"] = (
+                    organism.get("taxonomy_name") if organism is not None else None
+                )
+                bios["taxon_id"] = (
+                    int(organism.get("taxonomy_id")) if organism is not None else None
+                )
                 bios["attribute_recs"] = []
                 bios["attributes"] = []
                 for attribute in elem.findall(".//Attribute"):
-                    attrec = attribute.attrib
+                    attrec = dict(attribute.attrib)
                     attrec["value"] = attribute.text
                     bios["attribute_recs"].append(attrec)
                     try:

--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
@@ -474,17 +474,15 @@ def _parse_single_gsm_soft(d2):
         if k.startswith("supplementa"):
             supp_files += d2[k]
             del d2[k]
-    d2["supplemental_files"] = supp_files
-    if supp_files[0] == "NONE":
+    if supp_files == ["NONE"]:
         supp_files = []
+    d2["supplemental_files"] = supp_files
     d2["_entity"] = "GSM"
     d2 = _fix_date_fields(d2)
     # Collapse protocol fields into single string
     for k in filter(lambda k: k.endswith("protocol"), d2.keys()):
         if isinstance(d2[k], list):
             d2[k] = " ".join(d2[k])
-    if "contributor" in d2:
-        d2["contributor"] = _split_contributor_names(d2["contributor"])
     return pydantic_models.GEOSample(**d2)
 
 

--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/pydantic_models.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/pydantic_models.py
@@ -71,7 +71,7 @@ class GEOChannel(BaseModel):
 class GEOSample(GEOBase):
     type: str
     anchor: str | None = None
-    _entity: None
+    _entity: str = "GSM"
     contact: GEOContact | None = None
     description: str | None = None
     accession: Annotated[str, Field(pattern=r"GSM[0-9]+")]

--- a/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
@@ -77,15 +77,17 @@ def parse_xml_file(xmlfilename):
     if "study" in xmlfilename:
         entity = "STUDY"
         sra_parser = SRAStudyRecord
-    if "run" in xmlfilename:
+    elif "run" in xmlfilename:
         entity = "RUN"
         sra_parser = SRARunRecord
-    if "sample" in xmlfilename:
+    elif "sample" in xmlfilename:
         entity = "SAMPLE"
         sra_parser = SRASampleRecord
-    if "experiment" in xmlfilename:
+    elif "experiment" in xmlfilename:
         entity = "EXPERIMENT"
         sra_parser = SRAExperimentRecord
+    else:
+        raise ValueError(f"Cannot infer SRA entity type from filename: {xmlfilename}")
     n = 0
     open_func = gzip.open if xmlfilename.endswith(".gz") else open
     with open_func(xmlfilename) as f:
@@ -196,7 +198,7 @@ def parse_run(xml: etree.Element) -> dict:
     for k in ["total_spots", "total_bases", "size"]:
         with contextlib.suppress(KeyError, ValueError, TypeError):
             d[k] = int(d[k])
-    with contextlib.suppress(BaseException):
+    with contextlib.suppress(Exception):
         d["avg_length"] = float(d["total_bases"]) / d["total_spots"]
     path_map = {
         "experiment_accession": ("EXPERIMENT_REF", "accession"),
@@ -207,7 +209,6 @@ def parse_run(xml: etree.Element) -> dict:
     # d = try_update(d, _parse_run_reads(xml.find(".//SPOT_DESCRIPTOR")))
     d.update(_process_path_map(xml, path_map))
     d.update(_parse_identifiers(xml.find("IDENTIFIERS"), "run"))
-    d = try_update(d, _parse_attributes(xml.find("RUN_ATTRIBUTES")))
     d = try_update(d, _parse_attributes(xml.find("RUN_ATTRIBUTES")))
     d = try_update(d, _parse_run_files(xml.find("SRAFiles")))
     d = try_update(d, _parse_run_stats(xml.find("Statistics")))
@@ -396,13 +397,13 @@ def _parse_run_reads(node: etree.Element | None) -> dict:
 
     for read in readrecs:
         r = {}
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception):
             r["read_index"] = int(read.find("./READ_INDEX").text)
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception):
             r["read_class"] = read.find("./READ_CLASS").text
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception):
             r["read_type"] = read.find("./READ_TYPE").text
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception):
             r["base_coord"] = int(read.find("./BASE_COORD").text)
         d["reads"].append(r)
 
@@ -415,7 +416,7 @@ def _parse_run_qualities(node: etree.Element) -> dict:
     d["qualities"] = []
     qualrecs = node.findall(".//Quality")
     for qual in qualrecs:
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception):
             d["qualities"].append(
                 {"quality": int(qual.get("value")), "count": int(qual.get("count"))}
             )
@@ -678,9 +679,7 @@ class SRAXMLRecord:
         self.parse_xml()
 
     def parse_xml(self):
-        d = {}
-        d = d.update(self.xml.attrib)
-        self.data = d
+        self.data = dict(self.xml.attrib)
 
 
 class SRAExperimentRecord(SRAXMLRecord):

--- a/packages/omicidx-parsers/src/omicidx/parsers/sra/pydantic_models.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/sra/pydantic_models.py
@@ -41,8 +41,7 @@ class BaseQualityCount(BaseModel):
     count: int = 0
 
 
-class BaseQualities(BaseModel):
-    pass
+BaseQualities = list[BaseQualityCount]
 
 
 class TaxCountEntry(BaseModel):
@@ -68,8 +67,7 @@ class RunRead(BaseModel):
     sd_length: float = 0.0
 
 
-class BaseCounts(BaseModel):  # (List[Dict[str, int]]):
-    pass
+BaseCounts = list[dict[str, int]]
 
 
 class LiveList(BaseModel):
@@ -122,7 +120,7 @@ class SraStudy(LiveList, BaseModel):
 
 class SraExperiment(LiveList, BaseModel):
     accession: str
-    attributes: list[Attribute] = None
+    attributes: list[Attribute] = []
     alias: str | None = None
     center_name: str | None = None
     design: str | None = None


### PR DESCRIPTION
## Summary

Fixes 10 critical and medium-severity bugs identified in the Opus code review. Closes #36, #37 (partially).

### Pydantic v2 model correctness
- `GEOSample._entity: None` → `_entity: str = "GSM"` — was an invalid type annotation, silently ignored by Pydantic
- `SraExperiment.attributes: list[Attribute] = None` → `= []` — Pydantic v2 rejects `None` as a list default
- `BioSample` / `BioProject`: all `str | None` fields now have `= None` defaults — Pydantic v2 treats them as required without it
- `BioSample.taxonomy_name` / `taxon_id`: made nullable to handle records with no `<Organism>` element
- `BaseQualities` / `BaseCounts`: replaced empty stub `BaseModel` subclasses with correct type aliases (`list[BaseQualityCount]`, `list[dict[str, int]]`) matching what the parsers actually produce — constructing `SraRun` from parsed data no longer fails validation
- `biosample.py` doctest: `bios.json()` / `bios.dict()` → `model_dump_json()` / `model_dump()`

### Parser logic
- **`_parse_single_gsm_soft`** (`geo/parser.py`): `supp_files[0]` IndexError on empty list — guard reordered to `if supp_files == ["NONE"]: supp_files = []` before assignment
- **`_parse_single_gsm_soft`**: duplicate `_split_contributor_names` call at end of function crashes because it applies `str.split` to already-split dicts — removed duplicate block
- **`parse_xml_file`** (`sra/parser.py`): `if`/`if`/`if`/`if` chain changed to `elif` — previously all branches ran and entity was unbound on no match (`UnboundLocalError`); added `else: raise ValueError`
- **`parse_run`**: duplicate `_parse_attributes(xml.find("RUN_ATTRIBUTES"))` call removed
- **`SRAXMLRecord.parse_xml`**: `d = d.update(...)` stores `None` in `self.data` — fixed to `self.data = dict(self.xml.attrib)`
- **`contextlib.suppress(BaseException)`** → `suppress(Exception)` throughout — previously swallowed `KeyboardInterrupt`, `SystemExit`
- **`biosample.py` attribute parsing**: `attribute.attrib` returned a live reference to the XML element's dict — `dict(attribute.attrib)` copies it before mutation

## Test plan
- [x] `uv run pytest packages/omicidx-parsers/tests/ -x -q` — 47 passed, 6 skipped