### PR TITLE
feat(dagster): postgres load assets for all entities (#56)

### DIFF
--- a/packages/omicidx-api/pyproject.toml
+++ b/packages/omicidx-api/pyproject.toml
@@ -22,4 +22,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/omicidx"]
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+
 [tool.uv.sources]

--- a/packages/omicidx-api/src/omicidx/api/config.py
+++ b/packages/omicidx-api/src/omicidx/api/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     def async_database_url(self) -> str:
         """Convert standard postgresql:// URI to asyncpg driver URI."""
         return self.database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
     db_pool_size: int = 10
     db_max_overflow: int = 20
 

--- a/packages/omicidx-api/src/omicidx/api/routers/bioproject.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/bioproject.py
@@ -26,7 +26,9 @@ async def get_bioproject(accession: str, session: Session):
 async def list_bioprojects(
     session: Session,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(BioProject).order_by(BioProject.accession).limit(limit + 1)
 

--- a/packages/omicidx-api/src/omicidx/api/routers/biosample.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/biosample.py
@@ -44,7 +44,9 @@ async def list_biosamples(
     date_from: date | None = None,
     date_to: date | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(BioSample).order_by(BioSample.accession).limit(limit + 1)
 

--- a/packages/omicidx-api/src/omicidx/api/routers/geo.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/geo.py
@@ -34,7 +34,9 @@ async def list_series(
     date_from: date | None = None,
     date_to: date | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(GEOSeries).order_by(GEOSeries.accession).limit(limit + 1)
 
@@ -56,8 +58,11 @@ async def list_series(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/geo/series", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/geo/series",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )
 
 
@@ -91,7 +96,9 @@ async def list_samples(
     organism: str | None = None,
     platform_id: str | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(GEOSample).order_by(GEOSample.accession).limit(limit + 1)
 
@@ -109,8 +116,11 @@ async def list_samples(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/geo/samples", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/geo/samples",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )
 
 
@@ -130,7 +140,9 @@ async def list_platforms(
     session: Session,
     organism: str | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(GEOPlatform).order_by(GEOPlatform.accession).limit(limit + 1)
 
@@ -146,6 +158,9 @@ async def list_platforms(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/geo/platforms", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/geo/platforms",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )

--- a/packages/omicidx-api/src/omicidx/api/routers/pubmed.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/pubmed.py
@@ -30,7 +30,9 @@ async def list_articles(
     date_from: date | None = None,
     date_to: date | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(PubMedArticle).order_by(PubMedArticle.pmid).limit(limit + 1)
 
@@ -50,6 +52,9 @@ async def list_articles(
     next_cursor = encode_cursor(rows[limit - 1].pmid) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/pubmed", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/pubmed",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )

--- a/packages/omicidx-api/src/omicidx/api/routers/sra.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/sra.py
@@ -45,7 +45,9 @@ async def list_studies(
     date_from: date | None = None,
     date_to: date | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(SraStudy).order_by(SraStudy.accession).limit(limit + 1)
 
@@ -67,8 +69,11 @@ async def list_studies(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/sra/studies", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/sra/studies",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )
 
 
@@ -96,7 +101,9 @@ async def list_samples(
     organism: str | None = None,
     tax_id: int | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(SraSample).order_by(SraSample.accession).limit(limit + 1)
 
@@ -114,8 +121,11 @@ async def list_samples(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/sra/samples", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/sra/samples",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )
 
 
@@ -150,7 +160,9 @@ async def list_experiments(
     library_source: str | None = None,
     platform: str | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(SraExperiment).order_by(SraExperiment.accession).limit(limit + 1)
 
@@ -170,8 +182,11 @@ async def list_experiments(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/sra/experiments", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/sra/experiments",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )
 
 
@@ -199,7 +214,9 @@ async def list_runs(
     session: Session,
     experiment_accession: str | None = None,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=settings.max_page_size)] = settings.default_page_size,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
 ):
     stmt = select(SraRun).order_by(SraRun.accession).limit(limit + 1)
 
@@ -215,6 +232,9 @@ async def list_runs(
     next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
 
     return build_list_response(
-        items=items, path="/v1/sra/runs", limit=limit,
-        next_cursor=next_cursor, cursor_param=cursor,
+        items=items,
+        path="/v1/sra/runs",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
     )

--- a/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
+++ b/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
@@ -50,7 +50,11 @@ def build_list_response(
     base = path.split("?")[0]
 
     next_link = f"{base}?cursor={next_cursor}&limit={limit}" if next_cursor else None
-    self_link = f"{base}?cursor={cursor_param}&limit={limit}" if cursor_param else f"{base}?limit={limit}"
+    self_link = (
+        f"{base}?cursor={cursor_param}&limit={limit}"
+        if cursor_param
+        else f"{base}?limit={limit}"
+    )
 
     return {
         "data": items,
@@ -77,7 +81,5 @@ def build_item_response(
     """Build a single-item envelope dict."""
     result: dict[str, Any] = {"data": item}
     if relationships:
-        result["relationships"] = {
-            k: v.model_dump() for k, v in relationships.items()
-        }
+        result["relationships"] = {k: v.model_dump() for k, v in relationships.items()}
     return result

--- a/packages/omicidx-api/tests/test_envelope.py
+++ b/packages/omicidx-api/tests/test_envelope.py
@@ -45,7 +45,9 @@ def test_build_list_response_with_cursor_param():
 
 
 def test_build_item_response_without_relationships():
-    result = build_item_response(item={"accession": "SAMN1", "organism": "Homo sapiens"})
+    result = build_item_response(
+        item={"accession": "SAMN1", "organism": "Homo sapiens"}
+    )
     assert result["data"]["accession"] == "SAMN1"
     assert "relationships" not in result
 

--- a/packages/omicidx-dagster/src/omicidx/dagster/definitions.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/definitions.py
@@ -30,7 +30,18 @@ from omicidx.dagster.defs.geo import (  # noqa: E402
     geo_raw,
     geo_rna_seq_counts,
 )
-from omicidx.dagster.defs.postgres import bioproject_postgres  # noqa: E402
+from omicidx.dagster.defs.postgres import (  # noqa: E402
+    bioproject_postgres,
+    biosample_postgres,
+    geo_platform_postgres,
+    geo_sample_postgres,
+    geo_series_postgres,
+    pubmed_postgres,
+    sra_experiment_postgres,
+    sra_run_postgres,
+    sra_sample_postgres,
+    sra_study_postgres,
+)
 from omicidx.dagster.defs.pubmed import pubmed_raw, pubmed_sensor  # noqa: E402
 from omicidx.dagster.defs.sql import omicidx_duckdb  # noqa: E402
 from omicidx.dagster.defs.sra import sra_mirror_listing, sra_raw  # noqa: E402
@@ -104,6 +115,15 @@ defs = dg.Definitions(
         omicidx_duckdb,
         # Postgres (API serving)
         bioproject_postgres,
+        biosample_postgres,
+        sra_study_postgres,
+        sra_sample_postgres,
+        sra_experiment_postgres,
+        sra_run_postgres,
+        geo_series_postgres,
+        geo_sample_postgres,
+        geo_platform_postgres,
+        pubmed_postgres,
     ],
     schedules=[daily_extract_schedule, daily_geo_schedule],
     sensors=[pubmed_sensor],

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/biosample.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/biosample.py
@@ -9,13 +9,14 @@ import shutil
 import tempfile
 import time
 
-import dagster as dg
 import httpx
 import orjson
 import tenacity
-from omicidx.parsers.biosample import BioProjectParser, BioSampleParser
 from omicidx.dagster.resources import DuckDBResource, OmicidxStorage
+from omicidx.parsers.biosample import BioProjectParser, BioSampleParser
 from upath import UPath
+
+import dagster as dg
 
 BIOSAMPLE_URL = "https://ftp.ncbi.nlm.nih.gov/biosample/biosample_set.xml.gz"
 BIOPROJECT_URL = "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml"
@@ -60,9 +61,7 @@ def _extract_entity(
 
         open_fn = gzip.open if use_gzip_input else open
 
-        with tempfile.NamedTemporaryFile(
-            suffix=".jsonl.gz", delete=False
-        ) as out_tmp:
+        with tempfile.NamedTemporaryFile(suffix=".jsonl.gz", delete=False) as out_tmp:
             out_tmp_path = out_tmp.name
 
         try:
@@ -176,7 +175,9 @@ def bioproject_parquet(
 ) -> dg.MaterializeResult:
     """Convert BioProject JSONL to Parquet using DuckDB."""
     input_path = storage.get_duckdb_path("bioproject", "raw", "data.jsonl.gz")
-    output_path = storage.get_duckdb_path("bioproject", "parquet", "bioprojects.parquet")
+    output_path = storage.get_duckdb_path(
+        "bioproject", "parquet", "bioprojects.parquet"
+    )
 
     sql = f"""
         COPY (

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
@@ -83,8 +83,11 @@ def geo_platforms_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("geo", "parquet", "geo_platforms.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("geo", "parquet", "geo_platforms.parquet"),
     )
 
 
@@ -119,8 +122,11 @@ def geo_series_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("geo", "parquet", "geo_series.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("geo", "parquet", "geo_series.parquet"),
     )
 
 
@@ -158,8 +164,11 @@ def geo_samples_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("geo", "parquet", "geo_samples.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("geo", "parquet", "geo_samples.parquet"),
     )
 
 
@@ -175,8 +184,12 @@ def geo_rnaseq_counts_parquet(
     duckdb_res: DuckDBResource,
     storage: OmicidxStorage,
 ) -> dg.MaterializeResult:
-    output = storage.get_duckdb_path("geo", "parquet", "geo_series_with_rnaseq_counts.parquet")
-    input_path = storage.get_duckdb_path("geo", "raw", "gse_with_rna_seq_counts.parquet")
+    output = storage.get_duckdb_path(
+        "geo", "parquet", "geo_series_with_rnaseq_counts.parquet"
+    )
+    input_path = storage.get_duckdb_path(
+        "geo", "raw", "gse_with_rna_seq_counts.parquet"
+    )
     sql = f"""
         COPY (
             SELECT accession.accession as accession
@@ -185,8 +198,11 @@ def geo_rnaseq_counts_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("geo", "parquet", "geo_series_with_rnaseq_counts.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("geo", "parquet", "geo_series_with_rnaseq_counts.parquet"),
     )
 
 
@@ -226,8 +242,11 @@ def sra_studies_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("sra", "parquet", "sra_studies.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("sra", "parquet", "sra_studies.parquet"),
     )
 
 
@@ -260,8 +279,11 @@ def sra_samples_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("sra", "parquet", "sra_samples.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("sra", "parquet", "sra_samples.parquet"),
     )
 
 
@@ -306,8 +328,11 @@ def sra_experiments_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("sra", "parquet", "sra_experiments.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("sra", "parquet", "sra_experiments.parquet"),
     )
 
 
@@ -338,8 +363,11 @@ def sra_runs_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("sra", "parquet", "sra_runs.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("sra", "parquet", "sra_runs.parquet"),
     )
 
 
@@ -381,8 +409,11 @@ def sra_accessions_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("sra", "parquet", "sra_accessions.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("sra", "parquet", "sra_accessions.parquet"),
     )
 
 
@@ -428,8 +459,11 @@ def biosample_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("biosample", "parquet", "biosamples.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("biosample", "parquet", "biosamples.parquet"),
     )
 
 
@@ -477,6 +511,9 @@ def pubmed_parquet(
         ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
     """
     return _consolidate(
-        context=context, duckdb_res=duckdb_res, storage=storage,
-        sql=sql, output_parts=("pubmed", "parquet", "pubmed_articles.parquet"),
+        context=context,
+        duckdb_res=duckdb_res,
+        storage=storage,
+        sql=sql,
+        output_parts=("pubmed", "parquet", "pubmed_articles.parquet"),
     )

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/geo.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/geo.py
@@ -10,14 +10,15 @@ import shutil
 import tempfile
 from datetime import date, datetime, timedelta
 
-import dagster as dg
 import httpx
 import polars as pl
 import tenacity
 from dateutil.relativedelta import relativedelta
-from omicidx.parsers.geo import parser as gp
 from omicidx.dagster.resources import OmicidxStorage
+from omicidx.parsers.geo import parser as gp
 from upath import UPath
+
+import dagster as dg
 
 geo_monthly_partitions = dg.MonthlyPartitionsDefinition(
     start_date="2005-01-01",
@@ -62,9 +63,7 @@ def _entrezid_to_geo(entrezid: str) -> str:
         )
     ),
 )
-async def _fetch_accessions(
-    start_date: date, end_date: date
-) -> list[str]:
+async def _fetch_accessions(start_date: date, end_date: date) -> list[str]:
     """Query Entrez eutils for GEO accessions updated in a date range."""
     accessions = []
     offset = 0
@@ -77,7 +76,7 @@ async def _fetch_accessions(
                 params={
                     "db": "gds",
                     "term": (
-                        f'(GSM[etyp] OR GSE[etyp] OR GPL[etyp]) AND '
+                        f"(GSM[etyp] OR GSE[etyp] OR GPL[etyp]) AND "
                         f'("{start_date.strftime("%Y/%m/%d")}"[Update Date] : '
                         f'"{end_date.strftime("%Y/%m/%d")}"[Update Date])'
                     ),
@@ -210,6 +209,7 @@ def geo_rna_seq_counts(
                 break
             offset += retmax
             import time
+
             time.sleep(0.5)
 
     df = pl.DataFrame(accessions)
@@ -292,7 +292,8 @@ def geo_raw(
         counts = {}
         for prefix, entity in [("GSE", "gse"), ("GSM", "gsm"), ("GPL", "gpl")]:
             path = (
-                output_base / entity
+                output_base
+                / entity
                 / f"year={start_date.strftime('%Y')}"
                 / f"month={start_date.strftime('%m')}"
                 / "data_0.ndjson.gz"
@@ -309,14 +310,14 @@ def geo_raw(
     parsed = asyncio.run(_fetch_and_parse_accessions(accessions))
 
     # 3. Write each entity type
-    metadata = {}
     for prefix, entity, output_name in [
         ("GSE", "gse", "geo_gse_raw"),
         ("GSM", "gsm", "geo_gsm_raw"),
         ("GPL", "gpl", "geo_gpl_raw"),
     ]:
         path = (
-            output_base / entity
+            output_base
+            / entity
             / f"year={start_date.strftime('%Y')}"
             / f"month={start_date.strftime('%m')}"
             / "data_0.ndjson.gz"

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -74,6 +74,22 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
                 {"view_name": view_name},
             )
             view_exists = view_exists_result.first() is not None
+            referenced_result = await conn.execute(
+                text("""
+                    SELECT DISTINCT cls.relname
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    JOIN pg_rewrite rw ON rw.ev_class = view_cls.oid
+                    JOIN pg_depend dep ON dep.objid = rw.oid
+                    JOIN pg_class cls ON cls.oid = dep.refobjid
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                      AND cls.relkind IN ('r', 'p')
+                """),
+                {"view_name": view_name},
+            )
+            referenced_tables = [row[0] for row in referenced_result.fetchall()]
             slot_a = f"{view_name}_a"
             slot_b = f"{view_name}_b"
             result = await conn.execute(
@@ -98,9 +114,11 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
         await engine.dispose()
         if not rows:
             if view_exists:
+                referenced = ", ".join(referenced_tables) if referenced_tables else "none"
                 raise ValueError(
                     f"View {view_name!r} does not reference expected A/B tables "
-                    f"({slot_a}, {slot_b}). Check for manual schema/view changes."
+                    f"({slot_a}, {slot_b}); found: {referenced}. "
+                    "Check for manual schema/view changes."
                 )
             return None
         if len(rows) > 1:

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -114,7 +114,7 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
         await engine.dispose()
         if not rows:
             if view_exists:
-                referenced = ", ".join(referenced_tables) if referenced_tables else "none"
+                referenced = ", ".join(referenced_tables) or "none"
                 raise ValueError(
                     f"View {view_name!r} does not reference expected A/B tables "
                     f"({slot_a}, {slot_b}); found: {referenced}. "

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -25,6 +25,34 @@ _PG_TAGS = {
 }
 
 
+def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str | None:
+    """Check which backing table a view currently points to, or None if no view."""
+    import asyncio
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async def _check():
+        engine = create_async_engine(postgres.async_uri)
+        async with engine.begin() as conn:
+            result = await conn.execute(text(
+                "SELECT definition FROM pg_views WHERE viewname = :name"
+            ), {"name": view_name})
+            row = result.first()
+        await engine.dispose()
+        if row is None:
+            return None
+        defn = row[0]
+        # definition looks like: " SELECT ... FROM {table}_a;" or "{table}_b"
+        if f"{view_name}_b" in defn:
+            return f"{view_name}_b"
+        if f"{view_name}_a" in defn:
+            return f"{view_name}_a"
+        return None
+
+    return asyncio.run(_check())
+
+
 def _load_to_postgres(
     *,
     context: dg.AssetExecutionContext,
@@ -36,16 +64,44 @@ def _load_to_postgres(
     parquet_parts: tuple[str, ...],
     insert_sql_template: str,
 ) -> dg.MaterializeResult:
-    """Shared helper: DDL via asyncpg, bulk INSERT via DuckDB postgres_scanner."""
+    """Load parquet into Postgres with zero-downtime view swap.
+
+    The API reads from a view named `{table}`. Two backing tables alternate:
+    `{table}_a` and `{table}_b`. Each reload writes to whichever is NOT
+    currently backing the view, swaps the view, then drops the old one.
+
+    CREATE OR REPLACE VIEW only takes AccessShareLock — reads never block.
+    """
     parquet_path = storage.get_duckdb_path(*parquet_parts)
+    tbl_a = f"{table}_a"
+    tbl_b = f"{table}_b"
 
-    context.log.info(f"Ensuring {table} table exists")
-    postgres.execute_sql(ddl, f"TRUNCATE {table}")
+    # Determine which slot is currently live by checking the view definition
+    # If no view exists yet (first run), both slots are free — use _a
+    live = _get_live_backing_table(postgres, table)
+    target = tbl_b if live == tbl_a else tbl_a
 
+    # Create and load the target table
+    context.log.info(f"Loading into {target} (live={live or 'none'})")
+    target_ddl = ddl.replace(table, target)
+    postgres.execute_sql(
+        f"DROP TABLE IF EXISTS {target} CASCADE",
+        target_ddl,
+    )
+
+    target_insert = insert_sql_template.replace(f"pg.{table}", f"pg.{target}")
     with duckdb_res.get_connection() as con, postgres.attach(con):
-        context.log.info(f"Loading {table} from {parquet_path}")
-        con.execute(insert_sql_template.format(path=parquet_path))
-        row_count = con.execute(f"SELECT count(*) FROM pg.{table}").fetchone()[0]
+        context.log.info(f"Loading {target} from {parquet_path}")
+        con.execute(target_insert.format(path=parquet_path))
+        row_count = con.execute(f"SELECT count(*) FROM pg.{target}").fetchone()[0]
+
+    # Swap view to target, drop old backing table
+    context.log.info(f"Swapping view {table} → {target} ({row_count:,} rows)")
+    postgres.execute_sql(
+        f"CREATE OR REPLACE VIEW {table} AS SELECT * FROM {target}",
+    )
+    if live:
+        postgres.execute_sql(f"DROP TABLE IF EXISTS {live} CASCADE")
 
     context.log.info(f"Loaded {row_count:,} rows into {table}")
     return dg.MaterializeResult(

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -136,7 +136,10 @@ def _load_to_postgres(
 
     source_table = f"pg.{table}"
     if source_table not in insert_sql_template:
-        raise ValueError(f"Insert template must contain {source_table}")
+        raise ValueError(
+            f"Insert template must contain {source_table} so loads can be redirected "
+            "to the inactive A/B backing table."
+        )
     target_insert = insert_sql_template.replace(source_table, f"pg.{target}")
     with duckdb_res.get_connection() as con, postgres.attach(con):
         context.log.info(f"Loading {target} from {parquet_path}")

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -28,7 +28,10 @@ _PG_TAGS = {
 
 
 def _validate_sql_identifier(name: str) -> str:
-    """Validate an unquoted PostgreSQL identifier and return it unchanged."""
+    """Validate an unquoted PostgreSQL identifier and return it unchanged.
+
+    Unquoted identifiers are case-insensitive (folded to lowercase) in Postgres.
+    """
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
         raise ValueError(f"Invalid SQL identifier: {name!r}")
     return name
@@ -134,13 +137,13 @@ def _load_to_postgres(
         target_ddl,
     )
 
-    source_table = f"pg.{table}"
-    if source_table not in insert_sql_template:
+    source_table_pattern = rf"\bpg\.{re.escape(table)}\b"
+    if not re.search(source_table_pattern, insert_sql_template):
         raise ValueError(
-            f"Insert template must contain {source_table} so loads can be redirected "
+            f"Insert template must contain pg.{table} so loads can be redirected "
             "to the inactive A/B backing table."
         )
-    target_insert = insert_sql_template.replace(source_table, f"pg.{target}")
+    target_insert = re.sub(source_table_pattern, f"pg.{target}", insert_sql_template)
     with duckdb_res.get_connection() as con, postgres.attach(con):
         context.log.info(f"Loading {target} from {parquet_path}")
         con.execute(target_insert.format(path=parquet_path_literal))

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -1,5 +1,7 @@
 """Assets that load consolidated Parquet data into PostgreSQL for the API."""
 
+import re
+
 from omicidx.dagster.defs.biosample import bioproject_parquet
 from omicidx.dagster.defs.consolidate import (
     biosample_parquet,
@@ -25,6 +27,16 @@ _PG_TAGS = {
 }
 
 
+def _validate_sql_identifier(name: str) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        raise ValueError(f"Invalid SQL identifier: {name!r}")
+    return name
+
+
+def _quote_sql_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
 def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str | None:
     """Check which backing table a view currently points to, or None if no view."""
     import asyncio
@@ -35,20 +47,31 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
     async def _check():
         engine = create_async_engine(postgres.async_uri)
         async with engine.begin() as conn:
-            result = await conn.execute(text(
-                "SELECT definition FROM pg_views WHERE viewname = :name"
-            ), {"name": view_name})
-            row = result.first()
+            slot_a = f"{view_name}_a"
+            slot_b = f"{view_name}_b"
+            result = await conn.execute(
+                text("""
+                    SELECT DISTINCT cls.relname
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    JOIN pg_rewrite rw ON rw.ev_class = view_cls.oid
+                    JOIN pg_depend dep ON dep.objid = rw.oid
+                    JOIN pg_class cls ON cls.oid = dep.refobjid
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                      AND cls.relkind IN ('r', 'p')
+                      AND (cls.relname = :slot_a OR cls.relname = :slot_b)
+                """),
+                {"view_name": view_name, "slot_a": slot_a, "slot_b": slot_b},
+            )
+            rows = result.fetchall()
         await engine.dispose()
-        if row is None:
+        if not rows:
             return None
-        defn = row[0]
-        # definition looks like: " SELECT ... FROM {table}_a;" or "{table}_b"
-        if f"{view_name}_b" in defn:
-            return f"{view_name}_b"
-        if f"{view_name}_a" in defn:
-            return f"{view_name}_a"
-        return None
+        if len(rows) > 1:
+            raise ValueError(f"View {view_name!r} references multiple backing tables")
+        return rows[0][0]
 
     return asyncio.run(_check())
 
@@ -72,7 +95,9 @@ def _load_to_postgres(
 
     CREATE OR REPLACE VIEW only takes AccessShareLock — reads never block.
     """
+    table = _validate_sql_identifier(table)
     parquet_path = storage.get_duckdb_path(*parquet_parts)
+    parquet_path_literal = _quote_sql_literal(parquet_path)
     tbl_a = f"{table}_a"
     tbl_b = f"{table}_b"
 
@@ -89,10 +114,13 @@ def _load_to_postgres(
         target_ddl,
     )
 
-    target_insert = insert_sql_template.replace(f"pg.{table}", f"pg.{target}")
+    source_table = f"pg.{table}"
+    if source_table not in insert_sql_template:
+        raise ValueError(f"Insert template must contain {source_table}")
+    target_insert = insert_sql_template.replace(source_table, f"pg.{target}")
     with duckdb_res.get_connection() as con, postgres.attach(con):
         context.log.info(f"Loading {target} from {parquet_path}")
-        con.execute(target_insert.format(path=parquet_path))
+        con.execute(target_insert.format(path=parquet_path_literal))
         row_count = con.execute(f"SELECT count(*) FROM pg.{target}").fetchone()[0]
 
     # Swap view to target, drop old backing table

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -1,9 +1,62 @@
 """Assets that load consolidated Parquet data into PostgreSQL for the API."""
 
 from omicidx.dagster.defs.biosample import bioproject_parquet
+from omicidx.dagster.defs.consolidate import (
+    biosample_parquet,
+    geo_platforms_parquet,
+    geo_samples_parquet,
+    geo_series_parquet,
+    pubmed_parquet,
+    sra_experiments_parquet,
+    sra_runs_parquet,
+    sra_samples_parquet,
+    sra_studies_parquet,
+)
 from omicidx.dagster.resources import DuckDBResource, OmicidxStorage, PostgresResource
 
 import dagster as dg
+
+_PG_TAGS = {
+    "layer": "serving",
+    "cost": "low",
+    "sla": "daily",
+    "source": "derived",
+    "storage": "postgres",
+}
+
+
+def _load_to_postgres(
+    *,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
+    table: str,
+    ddl: str,
+    parquet_parts: tuple[str, ...],
+    insert_sql_template: str,
+) -> dg.MaterializeResult:
+    """Shared helper: DDL via asyncpg, bulk INSERT via DuckDB postgres_scanner."""
+    parquet_path = storage.get_duckdb_path(*parquet_parts)
+
+    context.log.info(f"Ensuring {table} table exists")
+    postgres.execute_sql(ddl, f"TRUNCATE {table}")
+
+    with duckdb_res.get_connection() as con, postgres.attach(con):
+        context.log.info(f"Loading {table} from {parquet_path}")
+        con.execute(insert_sql_template.format(path=parquet_path))
+        row_count = con.execute(f"SELECT count(*) FROM pg.{table}").fetchone()[0]
+
+    context.log.info(f"Loaded {row_count:,} rows into {table}")
+    return dg.MaterializeResult(
+        metadata={
+            "row_count": dg.MetadataValue.int(row_count),
+            "source_path": dg.MetadataValue.text(parquet_path),
+        }
+    )
+
+
+# -- BioProject ----------------------------------------------------------------
 
 _BIOPROJECT_DDL = """
 CREATE TABLE IF NOT EXISTS bioproject (
@@ -16,64 +69,523 @@ CREATE TABLE IF NOT EXISTS bioproject (
 )
 """
 
+_BIOPROJECT_INSERT = """
+INSERT INTO pg.bioproject (accession, name, title, release_date, data)
+SELECT accession, name, title, release_date, to_json({{
+    accession: accession, name: name, title: title,
+    description: description, release_date: release_date,
+    data_types: data_types, publications: publications,
+    external_links: external_links, locus_tags: locus_tags
+}})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
 
 @dg.asset(
-    group_name="postgres",
-    kinds={"postgres", "duckdb"},
-    tags={
-        "layer": "serving",
-        "cost": "low",
-        "sla": "daily",
-        "source": "derived",
-        "storage": "postgres",
-    },
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
     deps=[bioproject_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def bioproject_postgres(
-    context: dg.AssetExecutionContext,
-    storage: OmicidxStorage,
-    duckdb_res: DuckDBResource,
-    postgres: PostgresResource,
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
 ) -> dg.MaterializeResult:
-    """Load BioProject parquet into PostgreSQL for API serving."""
-    parquet_path = storage.get_duckdb_path("bioproject", "parquet", "bioprojects.parquet")
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="bioproject", ddl=_BIOPROJECT_DDL,
+        parquet_parts=("bioproject", "parquet", "bioprojects.parquet"),
+        insert_sql_template=_BIOPROJECT_INSERT,
+    )
 
-    # DDL via SQLAlchemy async + asyncpg (Postgres-native types like JSONB)
-    context.log.info("Ensuring bioproject table exists")
-    postgres.execute_sql(_BIOPROJECT_DDL, "TRUNCATE bioproject")
 
-    # Bulk load via DuckDB postgres_scanner (fast parquet → Postgres)
-    with duckdb_res.get_connection() as con, postgres.attach(con):
-        context.log.info(f"Loading from {parquet_path}")
-        con.execute(f"""
-            INSERT INTO pg.bioproject (accession, name, title, release_date, data)
-            SELECT
-                accession,
-                name,
-                title,
-                release_date,
-                to_json({{
-                    accession: accession,
-                    name: name,
-                    title: title,
-                    description: description,
-                    release_date: release_date,
-                    data_types: data_types,
-                    publications: publications,
-                    external_links: external_links,
-                    locus_tags: locus_tags
-                }})::TEXT AS data
-            FROM read_parquet('{parquet_path}')
-        """)
+# -- BioSample -----------------------------------------------------------------
 
-        row_count = con.execute("SELECT count(*) FROM pg.bioproject").fetchone()[0]
+_BIOSAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS biosample (
+    accession TEXT PRIMARY KEY,
+    sra_sample_id TEXT,
+    organism TEXT,
+    tax_id INTEGER,
+    submission_date DATE,
+    last_update DATE,
+    is_reference BOOLEAN,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_biosample_organism ON biosample (organism);
+CREATE INDEX IF NOT EXISTS ix_biosample_tax_id ON biosample (tax_id);
+CREATE INDEX IF NOT EXISTS ix_biosample_submission_date ON biosample (submission_date);
+CREATE INDEX IF NOT EXISTS ix_biosample_sra_sample_id ON biosample (sra_sample_id);
+"""
 
-    context.log.info(f"Loaded {row_count:,} bioprojects into PostgreSQL")
+_BIOSAMPLE_INSERT = """
+INSERT INTO pg.biosample (accession, sra_sample_id, organism, tax_id, submission_date, last_update, data)
+SELECT
+    accession, sra_sample, taxonomy_name, taxon_id,
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update AS DATE),
+    to_json({{
+        accession: accession, id: id, title: title,
+        description: description, taxonomy_name: taxonomy_name,
+        taxon_id: taxon_id, sra_sample: sra_sample,
+        dbgap: dbgap, gsm: gsm, model: model,
+        submission_date: submission_date, last_update: last_update,
+        publication_date: publication_date, access: access,
+        attribute_recs: attribute_recs, attributes: attributes,
+        id_recs: id_recs, ids: ids
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
 
-    return dg.MaterializeResult(
-        metadata={
-            "row_count": dg.MetadataValue.int(row_count),
-            "source_path": dg.MetadataValue.text(parquet_path),
-        }
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[biosample_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def biosample_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="biosample", ddl=_BIOSAMPLE_DDL,
+        parquet_parts=("biosample", "parquet", "biosamples.parquet"),
+        insert_sql_template=_BIOSAMPLE_INSERT,
+    )
+
+
+# -- SRA Study ------------------------------------------------------------------
+
+_SRA_STUDY_DDL = """
+CREATE TABLE IF NOT EXISTS sra_study (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    study_type TEXT,
+    title TEXT,
+    bioproject TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_sra_study_organism ON sra_study (organism);
+CREATE INDEX IF NOT EXISTS ix_sra_study_study_type ON sra_study (study_type);
+CREATE INDEX IF NOT EXISTS ix_sra_study_bioproject ON sra_study (bioproject);
+"""
+
+_SRA_STUDY_INSERT = """
+INSERT INTO pg.sra_study (accession, study_type, title, bioproject, data)
+SELECT
+    accession, study_type, title, bioproject,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        description: description, abstract: abstract,
+        study_type: study_type, center_name: center_name,
+        broker_name: broker_name, bioproject: bioproject,
+        geo: geo, identifiers: identifiers,
+        attributes: attributes, xrefs: xrefs,
+        pubmed_ids: pubmed_ids
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[sra_studies_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def sra_study_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="sra_study", ddl=_SRA_STUDY_DDL,
+        parquet_parts=("sra", "parquet", "sra_studies.parquet"),
+        insert_sql_template=_SRA_STUDY_INSERT,
+    )
+
+
+# -- SRA Sample -----------------------------------------------------------------
+
+_SRA_SAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS sra_sample (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    tax_id INTEGER,
+    biosample TEXT,
+    title TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_sra_sample_organism ON sra_sample (organism);
+CREATE INDEX IF NOT EXISTS ix_sra_sample_tax_id ON sra_sample (tax_id);
+CREATE INDEX IF NOT EXISTS ix_sra_sample_biosample ON sra_sample (biosample);
+"""
+
+_SRA_SAMPLE_INSERT = """
+INSERT INTO pg.sra_sample (accession, organism, tax_id, biosample, title, data)
+SELECT
+    accession, organism, taxon_id, biosample, title,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        organism: organism, taxon_id: taxon_id,
+        description: description, biosample: biosample,
+        identifiers: identifiers, attributes: attributes,
+        xrefs: xrefs
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[sra_samples_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def sra_sample_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="sra_sample", ddl=_SRA_SAMPLE_DDL,
+        parquet_parts=("sra", "parquet", "sra_samples.parquet"),
+        insert_sql_template=_SRA_SAMPLE_INSERT,
+    )
+
+
+# -- SRA Experiment -------------------------------------------------------------
+
+_SRA_EXPERIMENT_DDL = """
+CREATE TABLE IF NOT EXISTS sra_experiment (
+    accession TEXT PRIMARY KEY,
+    library_strategy TEXT,
+    library_source TEXT,
+    platform TEXT,
+    instrument_model TEXT,
+    sample_accession TEXT,
+    study_accession TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_library_strategy ON sra_experiment (library_strategy);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_library_source ON sra_experiment (library_source);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_platform ON sra_experiment (platform);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_sample_accession ON sra_experiment (sample_accession);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_study_accession ON sra_experiment (study_accession);
+"""
+
+_SRA_EXPERIMENT_INSERT = """
+INSERT INTO pg.sra_experiment (accession, library_strategy, library_source, platform, instrument_model, sample_accession, study_accession, data)
+SELECT
+    accession, library_strategy, library_source, platform,
+    instrument_model, sample_accession, study_accession,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        design: design, center_name: center_name,
+        study_accession: study_accession,
+        sample_accession: sample_accession,
+        platform: platform, instrument_model: instrument_model,
+        library_name: library_name,
+        library_construction_protocol: library_construction_protocol,
+        library_layout: library_layout,
+        library_strategy: library_strategy,
+        library_source: library_source,
+        library_selection: library_selection,
+        identifiers: identifiers, attributes: attributes,
+        xrefs: xrefs, reads: reads
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[sra_experiments_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def sra_experiment_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="sra_experiment", ddl=_SRA_EXPERIMENT_DDL,
+        parquet_parts=("sra", "parquet", "sra_experiments.parquet"),
+        insert_sql_template=_SRA_EXPERIMENT_INSERT,
+    )
+
+
+# -- SRA Run --------------------------------------------------------------------
+
+_SRA_RUN_DDL = """
+CREATE TABLE IF NOT EXISTS sra_run (
+    accession TEXT PRIMARY KEY,
+    experiment_accession TEXT,
+    total_spots INTEGER,
+    total_bases BIGINT,
+    published DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_sra_run_experiment_accession ON sra_run (experiment_accession);
+CREATE INDEX IF NOT EXISTS ix_sra_run_published ON sra_run (published);
+"""
+
+_SRA_RUN_INSERT = """
+INSERT INTO pg.sra_run (accession, experiment_accession, data)
+SELECT
+    accession, experiment_accession,
+    to_json({{
+        accession: accession, alias: alias,
+        experiment_accession: experiment_accession,
+        title: title, identifiers: identifiers,
+        attributes: attributes, qualities: qualities
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[sra_runs_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def sra_run_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="sra_run", ddl=_SRA_RUN_DDL,
+        parquet_parts=("sra", "parquet", "sra_runs.parquet"),
+        insert_sql_template=_SRA_RUN_INSERT,
+    )
+
+
+# -- GEO Series -----------------------------------------------------------------
+
+_GEO_SERIES_DDL = """
+CREATE TABLE IF NOT EXISTS geo_series (
+    accession TEXT PRIMARY KEY,
+    title TEXT,
+    organism TEXT,
+    series_type TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_geo_series_organism ON geo_series (organism);
+CREATE INDEX IF NOT EXISTS ix_geo_series_series_type ON geo_series (series_type);
+CREATE INDEX IF NOT EXISTS ix_geo_series_submission_date ON geo_series (submission_date);
+"""
+
+_GEO_SERIES_INSERT = """
+INSERT INTO pg.geo_series (accession, title, organism, series_type, submission_date, last_update, data)
+SELECT
+    accession, title, sample_organism[1], type[1],
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update_date AS DATE),
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        summary: summary, overall_design: overall_design,
+        type: type, contact: contact,
+        pubmed_id: pubmed_id, relation: relation,
+        sample_id: sample_id, platform_id: platform_id,
+        sample_organism: sample_organism,
+        platform_organism: platform_organism,
+        supplemental_files: supplemental_files,
+        subseries: subseries, bioprojects: bioprojects,
+        sra_studies: sra_studies, contributor: contributor
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[geo_series_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def geo_series_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="geo_series", ddl=_GEO_SERIES_DDL,
+        parquet_parts=("geo", "parquet", "geo_series.parquet"),
+        insert_sql_template=_GEO_SERIES_INSERT,
+    )
+
+
+# -- GEO Sample -----------------------------------------------------------------
+
+_GEO_SAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS geo_sample (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    platform_id TEXT,
+    series_id TEXT,
+    title TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_geo_sample_organism ON geo_sample (organism);
+CREATE INDEX IF NOT EXISTS ix_geo_sample_platform_id ON geo_sample (platform_id);
+CREATE INDEX IF NOT EXISTS ix_geo_sample_series_id ON geo_sample (series_id);
+"""
+
+_GEO_SAMPLE_INSERT = """
+INSERT INTO pg.geo_sample (accession, platform_id, title, submission_date, last_update, data)
+SELECT
+    accession, platform_id, title,
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update_date AS DATE),
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        type: type, description: description,
+        platform_id: platform_id, channel_count: channel_count,
+        channels: channels, contact: contact,
+        biosample: biosample, sra_experiment: sra_experiment,
+        library_source: library_source,
+        data_processing: data_processing,
+        supplemental_files: supplemental_files,
+        contributor: contributor
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[geo_samples_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def geo_sample_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="geo_sample", ddl=_GEO_SAMPLE_DDL,
+        parquet_parts=("geo", "parquet", "geo_samples.parquet"),
+        insert_sql_template=_GEO_SAMPLE_INSERT,
+    )
+
+
+# -- GEO Platform ---------------------------------------------------------------
+
+_GEO_PLATFORM_DDL = """
+CREATE TABLE IF NOT EXISTS geo_platform (
+    accession TEXT PRIMARY KEY,
+    title TEXT,
+    organism TEXT,
+    technology TEXT,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+)
+"""
+
+_GEO_PLATFORM_INSERT = """
+INSERT INTO pg.geo_platform (accession, title, organism, technology, data)
+SELECT
+    accession, title, organism, technology,
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        organism: organism, technology: technology,
+        description: description, distribution: distribution,
+        manufacturer: manufacturer, data_row_count: data_row_count,
+        contact: contact, contributor: contributor,
+        relation: relation
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[geo_platforms_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def geo_platform_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="geo_platform", ddl=_GEO_PLATFORM_DDL,
+        parquet_parts=("geo", "parquet", "geo_platforms.parquet"),
+        insert_sql_template=_GEO_PLATFORM_INSERT,
+    )
+
+
+# -- PubMed ---------------------------------------------------------------------
+
+_PUBMED_DDL = """
+CREATE TABLE IF NOT EXISTS pubmed_article (
+    pmid INTEGER PRIMARY KEY,
+    title TEXT,
+    journal TEXT,
+    pub_date DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_pubmed_article_journal ON pubmed_article (journal);
+CREATE INDEX IF NOT EXISTS ix_pubmed_article_pub_date ON pubmed_article (pub_date);
+"""
+
+_PUBMED_INSERT = """
+INSERT INTO pg.pubmed_article (pmid, title, journal, pub_date, data)
+SELECT
+    CAST(pmid AS INTEGER), title, journal,
+    TRY_CAST(pubdate AS DATE),
+    to_json({{
+        pmid: pmid, title: title, journal: journal,
+        pubdate: pubdate, abstract: abstract,
+        authors: authors, mesh_terms: mesh_terms,
+        publication_types: publication_types,
+        keywords: keywords, doi: doi,
+        pmc: pmc, issue: issue, pages: pages,
+        "references": "references",
+        languages: languages,
+        chemical_list: chemical_list,
+        grant_ids: grant_ids,
+        country: country, medline_ta: medline_ta
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+@dg.asset(
+    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    deps=[pubmed_parquet],
+    retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+)
+def pubmed_postgres(
+    context: dg.AssetExecutionContext, storage: OmicidxStorage,
+    duckdb_res: DuckDBResource, postgres: PostgresResource,
+) -> dg.MaterializeResult:
+    return _load_to_postgres(
+        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
+        table="pubmed_article", ddl=_PUBMED_DDL,
+        parquet_parts=("pubmed", "parquet", "pubmed_articles.parquet"),
+        insert_sql_template=_PUBMED_INSERT,
     )

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -62,6 +62,18 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
     async def _check():
         engine = create_async_engine(postgres.async_uri)
         async with engine.begin() as conn:
+            view_exists_result = await conn.execute(
+                text("""
+                    SELECT 1
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                """),
+                {"view_name": view_name},
+            )
+            view_exists = view_exists_result.first() is not None
             slot_a = f"{view_name}_a"
             slot_b = f"{view_name}_b"
             result = await conn.execute(
@@ -85,6 +97,11 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
             rows = result.fetchall()
         await engine.dispose()
         if not rows:
+            if view_exists:
+                raise ValueError(
+                    f"View {view_name!r} does not reference expected A/B tables "
+                    f"({slot_a}, {slot_b}). Check for manual schema/view changes."
+                )
             return None
         if len(rows) > 1:
             table_names = ", ".join(row[0] for row in rows)

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -60,6 +60,8 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
             slot_b = f"{view_name}_b"
             result = await conn.execute(
                 text("""
+                    -- Trace view dependencies through rewrite rules to find
+                    -- the underlying physical table backing the view.
                     SELECT DISTINCT cls.relname
                     FROM pg_class view_cls
                     JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
@@ -79,7 +81,10 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
         if not rows:
             return None
         if len(rows) > 1:
-            raise ValueError(f"View {view_name!r} references multiple backing tables")
+            table_names = ", ".join(row[0] for row in rows)
+            raise ValueError(
+                f"View {view_name!r} references multiple backing tables: {table_names}"
+            )
         return rows[0][0]
 
     return asyncio.run(_check())

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -227,17 +227,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[bioproject_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def bioproject_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="bioproject", ddl=_BIOPROJECT_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="bioproject",
+        ddl=_BIOPROJECT_DDL,
         parquet_parts=("bioproject", "parquet", "bioprojects.parquet"),
         insert_sql_template=_BIOPROJECT_INSERT,
     )
@@ -284,17 +292,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[biosample_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def biosample_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="biosample", ddl=_BIOSAMPLE_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="biosample",
+        ddl=_BIOSAMPLE_DDL,
         parquet_parts=("biosample", "parquet", "biosamples.parquet"),
         insert_sql_template=_BIOSAMPLE_INSERT,
     )
@@ -337,17 +353,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[sra_studies_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def sra_study_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="sra_study", ddl=_SRA_STUDY_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="sra_study",
+        ddl=_SRA_STUDY_DDL,
         parquet_parts=("sra", "parquet", "sra_studies.parquet"),
         insert_sql_template=_SRA_STUDY_INSERT,
     )
@@ -388,17 +412,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[sra_samples_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def sra_sample_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="sra_sample", ddl=_SRA_SAMPLE_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="sra_sample",
+        ddl=_SRA_SAMPLE_DDL,
         parquet_parts=("sra", "parquet", "sra_samples.parquet"),
         insert_sql_template=_SRA_SAMPLE_INSERT,
     )
@@ -452,17 +484,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[sra_experiments_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def sra_experiment_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="sra_experiment", ddl=_SRA_EXPERIMENT_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="sra_experiment",
+        ddl=_SRA_EXPERIMENT_DDL,
         parquet_parts=("sra", "parquet", "sra_experiments.parquet"),
         insert_sql_template=_SRA_EXPERIMENT_INSERT,
     )
@@ -500,17 +540,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[sra_runs_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def sra_run_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="sra_run", ddl=_SRA_RUN_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="sra_run",
+        ddl=_SRA_RUN_DDL,
         parquet_parts=("sra", "parquet", "sra_runs.parquet"),
         insert_sql_template=_SRA_RUN_INSERT,
     )
@@ -559,17 +607,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[geo_series_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def geo_series_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="geo_series", ddl=_GEO_SERIES_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="geo_series",
+        ddl=_GEO_SERIES_DDL,
         parquet_parts=("geo", "parquet", "geo_series.parquet"),
         insert_sql_template=_GEO_SERIES_INSERT,
     )
@@ -618,17 +674,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[geo_samples_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def geo_sample_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="geo_sample", ddl=_GEO_SAMPLE_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="geo_sample",
+        ddl=_GEO_SAMPLE_DDL,
         parquet_parts=("geo", "parquet", "geo_samples.parquet"),
         insert_sql_template=_GEO_SAMPLE_INSERT,
     )
@@ -666,17 +730,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[geo_platforms_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def geo_platform_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="geo_platform", ddl=_GEO_PLATFORM_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="geo_platform",
+        ddl=_GEO_PLATFORM_DDL,
         parquet_parts=("geo", "parquet", "geo_platforms.parquet"),
         insert_sql_template=_GEO_PLATFORM_INSERT,
     )
@@ -720,17 +792,25 @@ FROM read_parquet('{path}')
 
 
 @dg.asset(
-    group_name="postgres", kinds={"postgres", "duckdb"}, tags=_PG_TAGS,
+    group_name="postgres",
+    kinds={"postgres", "duckdb"},
+    tags=_PG_TAGS,
     deps=[pubmed_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
 )
 def pubmed_postgres(
-    context: dg.AssetExecutionContext, storage: OmicidxStorage,
-    duckdb_res: DuckDBResource, postgres: PostgresResource,
+    context: dg.AssetExecutionContext,
+    storage: OmicidxStorage,
+    duckdb_res: DuckDBResource,
+    postgres: PostgresResource,
 ) -> dg.MaterializeResult:
     return _load_to_postgres(
-        context=context, storage=storage, duckdb_res=duckdb_res, postgres=postgres,
-        table="pubmed_article", ddl=_PUBMED_DDL,
+        context=context,
+        storage=storage,
+        duckdb_res=duckdb_res,
+        postgres=postgres,
+        table="pubmed_article",
+        ddl=_PUBMED_DDL,
         parquet_parts=("pubmed", "parquet", "pubmed_articles.parquet"),
         insert_sql_template=_PUBMED_INSERT,
     )

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -33,8 +33,12 @@ def _validate_sql_identifier(name: str) -> str:
     return name
 
 
-def _quote_sql_literal(value: str) -> str:
+def _escape_sql_single_quotes(value: str) -> str:
     return value.replace("'", "''")
+
+
+def _escape_format_braces(value: str) -> str:
+    return value.replace("{", "{{").replace("}", "}}")
 
 
 def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str | None:
@@ -97,7 +101,9 @@ def _load_to_postgres(
     """
     table = _validate_sql_identifier(table)
     parquet_path = storage.get_duckdb_path(*parquet_parts)
-    parquet_path_literal = _quote_sql_literal(parquet_path)
+    parquet_path_literal = _escape_sql_single_quotes(
+        _escape_format_braces(parquet_path)
+    )
     tbl_a = f"{table}_a"
     tbl_b = f"{table}_b"
 

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -28,16 +28,19 @@ _PG_TAGS = {
 
 
 def _validate_sql_identifier(name: str) -> str:
+    """Validate an unquoted SQL identifier and return it unchanged."""
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
         raise ValueError(f"Invalid SQL identifier: {name!r}")
     return name
 
 
 def _escape_sql_single_quotes(value: str) -> str:
+    """Escape single quotes for SQL string literal usage."""
     return value.replace("'", "''")
 
 
 def _escape_format_braces(value: str) -> str:
+    """Escape braces so `str.format()` treats them as literal characters."""
     return value.replace("{", "{{").replace("}", "}}")
 
 
@@ -47,6 +50,8 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
 
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
+
+    view_name = _validate_sql_identifier(view_name)
 
     async def _check():
         engine = create_async_engine(postgres.async_uri)

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -28,7 +28,7 @@ _PG_TAGS = {
 
 
 def _validate_sql_identifier(name: str) -> str:
-    """Validate an unquoted SQL identifier and return it unchanged."""
+    """Validate an unquoted PostgreSQL identifier and return it unchanged."""
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
         raise ValueError(f"Invalid SQL identifier: {name!r}")
     return name
@@ -45,7 +45,10 @@ def _escape_format_braces(value: str) -> str:
 
 
 def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str | None:
-    """Check which backing table a view currently points to, or None if no view."""
+    """Return active `{view}_a|{view}_b` backing table, or None when not detected.
+
+    Raises ValueError when the view unexpectedly points to multiple A/B tables.
+    """
     import asyncio
 
     from sqlalchemy import text
@@ -83,7 +86,8 @@ def _get_live_backing_table(postgres: PostgresResource, view_name: str) -> str |
         if len(rows) > 1:
             table_names = ", ".join(row[0] for row in rows)
             raise ValueError(
-                f"View {view_name!r} references multiple backing tables: {table_names}"
+                f"View {view_name!r} references multiple backing tables: {table_names}. "
+                "Check for manual schema/view modifications or orphaned A/B tables."
             )
         return rows[0][0]
 

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/pubmed.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/pubmed.py
@@ -10,12 +10,13 @@ import tempfile
 from datetime import datetime
 from urllib.request import urlretrieve
 
-import dagster as dg
+import pubmed_parser as pp
 import pyarrow as pa
 import pyarrow.parquet as pq
-import pubmed_parser as pp
 from omicidx.dagster.resources import OmicidxStorage
 from upath import UPath
+
+import dagster as dg
 
 PUBMED_BASE = UPath("https://ftp.ncbi.nlm.nih.gov/pubmed")
 _XML_GZ_RE = re.compile(r"^(pubmed\d+n\d+)\.xml\.gz$")
@@ -113,9 +114,7 @@ def pubmed_sensor(context: dg.SensorEvaluationContext) -> dg.SensorResult:
     available = _list_pubmed_files()
     available_ids = set(available.keys())
 
-    existing = set(
-        context.instance.get_dynamic_partitions("pubmed_files")
-    )
+    existing = set(context.instance.get_dynamic_partitions("pubmed_files"))
 
     new_ids = sorted(available_ids - existing)
 
@@ -126,9 +125,7 @@ def pubmed_sensor(context: dg.SensorEvaluationContext) -> dg.SensorResult:
     context.log.info(f"Found {len(new_ids)} new PubMed files")
 
     return dg.SensorResult(
-        dynamic_partitions_requests=[
-            pubmed_partitions.build_add_request(new_ids)
-        ],
+        dynamic_partitions_requests=[pubmed_partitions.build_add_request(new_ids)],
         run_requests=[
             dg.RunRequest(
                 partition_key=pid,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
@@ -4,13 +4,19 @@ Builds the omicidx.duckdb file from consolidated parquet views (020-050 SQL).
 The consolidation step is now handled by per-entity assets in consolidate.py.
 """
 
+from __future__ import annotations
+
 import json
 import shutil
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import sqlglot
 from omicidx.dagster.resources import DuckDBResource, OmicidxStorage
+
+if TYPE_CHECKING:
+    import duckdb
 
 import dagster as dg
 
@@ -38,7 +44,7 @@ def _q(value: str) -> str:
 
 def _run_sql_file(
     name: str,
-    con: "duckdb.DuckDBPyConnection",
+    con: duckdb.DuckDBPyConnection,
     context: dg.AssetExecutionContext,
 ) -> None:
     """Run a SQL file, executing each statement individually."""

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/sra.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/sra.py
@@ -12,12 +12,13 @@ import re
 import shutil
 import tempfile
 
-import dagster as dg
 import pyarrow as pa
 import pyarrow.parquet as pq
-from omicidx.parsers.sra.parser import sra_object_generator
 from omicidx.dagster.resources import OmicidxStorage
+from omicidx.parsers.sra.parser import sra_object_generator
 from upath import UPath
+
+import dagster as dg
 
 ENTITIES = ["study", "sample", "experiment", "run"]
 
@@ -375,9 +376,7 @@ def sra_raw(
 
     if not current:
         context.log.warning(f"No current-batch files for {entity}")
-        return dg.MaterializeResult(
-            metadata={"row_count": dg.MetadataValue.int(0)}
-        )
+        return dg.MaterializeResult(metadata={"row_count": dg.MetadataValue.int(0)})
 
     out_dir = storage.get_upath("sra", "raw", entity)
 

--- a/packages/omicidx-dagster/src/omicidx/dagster/resources.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/resources.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from urllib.parse import urlparse
 
 import duckdb
+import sqlglot
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 from upath import UPath
@@ -94,13 +95,19 @@ class PostgresResource(dg.ConfigurableResource):
         return self.uri.replace("postgresql://", "postgresql+asyncpg://", 1)
 
     def execute_sql(self, *statements: str) -> None:
-        """Run raw SQL statements against Postgres via SQLAlchemy async + asyncpg."""
+        """Run SQL statements against Postgres via SQLAlchemy async + asyncpg.
+
+        Each input string is parsed with sqlglot to split multi-statement
+        SQL into individual statements, since asyncpg cannot execute
+        multiple statements in a single prepared statement call.
+        """
 
         async def _run():
             engine = create_async_engine(self.async_uri)
             async with engine.begin() as conn:
-                for stmt in statements:
-                    await conn.execute(text(stmt))
+                for sql in statements:
+                    for parsed in sqlglot.transpile(sql, read="postgres"):
+                        await conn.execute(text(parsed))
             await engine.dispose()
 
         asyncio.run(_run())

--- a/packages/omicidx-dagster/src/omicidx/dagster/resources.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/resources.py
@@ -94,6 +94,11 @@ class PostgresResource(dg.ConfigurableResource):
         """Convert standard postgresql:// to asyncpg driver URI."""
         return self.uri.replace("postgresql://", "postgresql+asyncpg://", 1)
 
+    @staticmethod
+    def _split_postgres_statements(sql: str) -> list[str]:
+        """Split SQL text into executable PostgreSQL statements."""
+        return [expr.sql(dialect="postgres") for expr in sqlglot.parse(sql, read="postgres")]
+
     def execute_sql(self, *statements: str) -> None:
         """Run SQL statements against Postgres via SQLAlchemy async + asyncpg.
 
@@ -106,8 +111,8 @@ class PostgresResource(dg.ConfigurableResource):
             engine = create_async_engine(self.async_uri)
             async with engine.begin() as conn:
                 for sql in statements:
-                    for parsed in sqlglot.transpile(sql, read="postgres"):
-                        await conn.execute(text(parsed))
+                    for stmt in self._split_postgres_statements(sql):
+                        await conn.execute(text(stmt))
             await engine.dispose()
 
         asyncio.run(_run())

--- a/packages/omicidx-dagster/src/omicidx/dagster/resources.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/resources.py
@@ -100,7 +100,11 @@ class PostgresResource(dg.ConfigurableResource):
         if not sql.strip():
             msg = "SQL statement cannot be empty"
             raise ValueError(msg)
-        parsed = [expr.sql(dialect="postgres") for expr in sqlglot.parse(sql, read="postgres")]
+        parsed = [
+            expr.sql(dialect="postgres")
+            for expr in sqlglot.parse(sql, read="postgres")
+            if expr is not None
+        ]
         if not parsed:
             msg = "No executable SQL statements were parsed"
             raise ValueError(msg)

--- a/packages/omicidx-dagster/src/omicidx/dagster/resources.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/resources.py
@@ -106,7 +106,10 @@ class PostgresResource(dg.ConfigurableResource):
             if expr is not None
         ]
         if not parsed:
-            msg = "No executable SQL statements were parsed"
+            msg = (
+                "SQL parsing produced no executable statements "
+                "(may contain only comments/whitespace or be malformed)"
+            )
             raise ValueError(msg)
         return parsed
 

--- a/packages/omicidx-dagster/src/omicidx/dagster/resources.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/resources.py
@@ -97,7 +97,14 @@ class PostgresResource(dg.ConfigurableResource):
     @staticmethod
     def _split_postgres_statements(sql: str) -> list[str]:
         """Split SQL text into executable PostgreSQL statements."""
-        return [expr.sql(dialect="postgres") for expr in sqlglot.parse(sql, read="postgres")]
+        if not sql.strip():
+            msg = "SQL statement cannot be empty"
+            raise ValueError(msg)
+        parsed = [expr.sql(dialect="postgres") for expr in sqlglot.parse(sql, read="postgres")]
+        if not parsed:
+            msg = "No executable SQL statements were parsed"
+            raise ValueError(msg)
+        return parsed
 
     def execute_sql(self, *statements: str) -> None:
         """Run SQL statements against Postgres via SQLAlchemy async + asyncpg.

--- a/packages/omicidx-parsers/pyproject.toml
+++ b/packages/omicidx-parsers/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "hatchling.build"
 packages = ["src/omicidx"]
 
 [tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
 markers = [
     "network: marks tests that require network access (deselect with '-m not network')",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ dev-dependencies = [
     "anyio[trio]>=4.0.0",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+markers = [
+    "network: marks tests that require network access (deselect with '-m not network')",
+]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 88


### PR DESCRIPTION
## Summary

Closes #56. Adds 9 new postgres load assets completing the full parquet → PostgreSQL pipeline for all API entities.

### Zero-downtime A/B table swap

The API reads from views, not tables directly. Each reload:
1. Writes to the inactive backing table (`_a` or `_b`)
2. `CREATE OR REPLACE VIEW` swaps the view (AccessShareLock — no read blocking)
3. Drops the old backing table

If a load fails mid-INSERT, the view still points at the previous good table. Next retry cleans up the partial load and starts fresh.

### New assets
| Asset | Postgres table | Approx rows |
|---|---|---|
| `biosample_postgres` | `biosample` | ~50M |
| `sra_study_postgres` | `sra_study` | ~1M |
| `sra_sample_postgres` | `sra_sample` | ~30M |
| `sra_experiment_postgres` | `sra_experiment` | ~30M |
| `sra_run_postgres` | `sra_run` | ~40M |
| `geo_series_postgres` | `geo_series` | ~200K |
| `geo_sample_postgres` | `geo_sample` | ~6M |
| `geo_platform_postgres` | `geo_platform` | ~30K |
| `pubmed_postgres` | `pubmed_article` | ~45M |

### Implementation
- Shared `_load_to_postgres()` helper for all 10 assets
- `_get_live_backing_table()` queries `pg_views` to determine which slot is active
- DDL matches `omicidx-api/models/tables.py` (typed index columns + `data JSONB`)
- `to_json({...})::TEXT` packs all parquet columns into JSONB

## Test plan

- [x] Definitions load with all 32 assets
- [x] Ruff lint clean
- [ ] Materialize assets from Dagster UI
- [ ] Verify API serves data from each entity endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)