### PR TITLE
feat(dagster): declarative automation cascade (#68)

### DIFF
--- a/packages/omicidx-dagster/src/omicidx/dagster/definitions.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/definitions.py
@@ -82,6 +82,17 @@ daily_geo_schedule = dg.build_schedule_from_partitioned_job(
 
 
 # ---------------------------------------------------------------------------
+# Automation
+# ---------------------------------------------------------------------------
+
+automation_sensor = dg.AutomationConditionSensorDefinition(
+    name="automation_sensor",
+    target=dg.AssetSelection.all(),
+    default_status=dg.DefaultSensorStatus.RUNNING,
+    minimum_interval_seconds=30,
+)
+
+# ---------------------------------------------------------------------------
 # Definitions
 # ---------------------------------------------------------------------------
 
@@ -126,7 +137,7 @@ defs = dg.Definitions(
         pubmed_postgres,
     ],
     schedules=[daily_extract_schedule, daily_geo_schedule],
-    sensors=[pubmed_sensor],
+    sensors=[pubmed_sensor, automation_sensor],
     resources={
         "storage": OmicidxStorage(),
         "duckdb_res": DuckDBResource(),

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/biosample.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/biosample.py
@@ -167,6 +167,7 @@ def bioproject_raw(
     },
     deps=[bioproject_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def bioproject_parquet(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
@@ -57,6 +57,7 @@ def _consolidate(
     tags={**_CONSOLIDATE_TAGS, "sla": "monthly"},
     deps=[geo_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_platforms_parquet(
     context: dg.AssetExecutionContext,
@@ -97,6 +98,7 @@ def geo_platforms_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "monthly"},
     deps=[geo_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_series_parquet(
     context: dg.AssetExecutionContext,
@@ -136,6 +138,7 @@ def geo_series_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "monthly"},
     deps=[geo_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_samples_parquet(
     context: dg.AssetExecutionContext,
@@ -178,6 +181,7 @@ def geo_samples_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=["geo_rna_seq_counts"],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_rnaseq_counts_parquet(
     context: dg.AssetExecutionContext,
@@ -215,6 +219,7 @@ def geo_rnaseq_counts_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[sra_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_studies_parquet(
     context: dg.AssetExecutionContext,
@@ -256,6 +261,7 @@ def sra_studies_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[sra_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_samples_parquet(
     context: dg.AssetExecutionContext,
@@ -293,6 +299,7 @@ def sra_samples_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[sra_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_experiments_parquet(
     context: dg.AssetExecutionContext,
@@ -342,6 +349,7 @@ def sra_experiments_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[sra_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_runs_parquet(
     context: dg.AssetExecutionContext,
@@ -376,6 +384,7 @@ def sra_runs_parquet(
     kinds={"duckdb", "parquet", "s3"},
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.on_cron("0 3 * * *"),
 )
 def sra_accessions_parquet(
     context: dg.AssetExecutionContext,
@@ -426,6 +435,7 @@ def sra_accessions_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[biosample_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def biosample_parquet(
     context: dg.AssetExecutionContext,
@@ -476,6 +486,7 @@ def biosample_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[pubmed_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def pubmed_parquet(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/consolidate.py
@@ -486,7 +486,13 @@ def biosample_parquet(
     tags={**_CONSOLIDATE_TAGS, "sla": "daily"},
     deps=[pubmed_raw],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
-    automation_condition=dg.AutomationCondition.eager(),
+    # PubMed raw lands hourly via the file sensor; eager() would cause
+    # full historical reconsolidation each hour. Run once daily, only
+    # if at least one new partition has arrived since last materialization.
+    automation_condition=(
+        dg.AutomationCondition.on_cron("0 3 * * *")
+        & dg.AutomationCondition.any_deps_updated()
+    ),
 )
 def pubmed_parquet(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -806,7 +806,13 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[pubmed_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
-    automation_condition=dg.AutomationCondition.eager(),
+    # PubMed updates hourly upstream; A/B reload of the full table is
+    # too heavy to run more than once a day. Run after pubmed_parquet
+    # finishes, only if it actually rebuilt.
+    automation_condition=(
+        dg.AutomationCondition.on_cron("0 4 * * *")
+        & dg.AutomationCondition.any_deps_updated()
+    ),
 )
 def pubmed_postgres(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/postgres.py
@@ -232,6 +232,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[bioproject_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def bioproject_postgres(
     context: dg.AssetExecutionContext,
@@ -297,6 +298,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[biosample_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def biosample_postgres(
     context: dg.AssetExecutionContext,
@@ -358,6 +360,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[sra_studies_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_study_postgres(
     context: dg.AssetExecutionContext,
@@ -417,6 +420,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[sra_samples_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_sample_postgres(
     context: dg.AssetExecutionContext,
@@ -489,6 +493,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[sra_experiments_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_experiment_postgres(
     context: dg.AssetExecutionContext,
@@ -545,6 +550,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[sra_runs_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def sra_run_postgres(
     context: dg.AssetExecutionContext,
@@ -612,6 +618,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[geo_series_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_series_postgres(
     context: dg.AssetExecutionContext,
@@ -679,6 +686,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[geo_samples_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_sample_postgres(
     context: dg.AssetExecutionContext,
@@ -735,6 +743,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[geo_platforms_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def geo_platform_postgres(
     context: dg.AssetExecutionContext,
@@ -797,6 +806,7 @@ FROM read_parquet('{path}')
     tags=_PG_TAGS,
     deps=[pubmed_parquet],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def pubmed_postgres(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
@@ -4,19 +4,14 @@ Builds the omicidx.duckdb file from consolidated parquet views (020-050 SQL).
 The consolidation step is now handled by per-entity assets in consolidate.py.
 """
 
-from __future__ import annotations
-
 import json
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import duckdb
 import sqlglot
 from omicidx.dagster.resources import DuckDBResource, OmicidxStorage
-
-if TYPE_CHECKING:
-    import duckdb
 
 import dagster as dg
 
@@ -88,6 +83,7 @@ DB_FILE = "omicidx.duckdb"
         "pubmed_parquet",
     ],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
+    automation_condition=dg.AutomationCondition.eager(),
 )
 def omicidx_duckdb(
     context: dg.AssetExecutionContext,

--- a/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
+++ b/packages/omicidx-dagster/src/omicidx/dagster/defs/sql.py
@@ -83,7 +83,14 @@ DB_FILE = "omicidx.duckdb"
         "pubmed_parquet",
     ],
     retry_policy=dg.RetryPolicy(max_retries=1, delay=60),
-    automation_condition=dg.AutomationCondition.eager(),
+    # Full DuckDB rebuild + S3 upload is too expensive to run on every
+    # individual upstream update. Run once daily (after the consolidation
+    # cascade has had time to settle), only if at least one upstream
+    # parquet has actually been refreshed since last build.
+    automation_condition=(
+        dg.AutomationCondition.on_cron("0 5 * * *")
+        & dg.AutomationCondition.any_deps_updated()
+    ),
 )
 def omicidx_duckdb(
     context: dg.AssetExecutionContext,


### PR DESCRIPTION
## Summary

Closes #68, closes #69. Adds Dagster declarative automation so downstream assets materialize automatically when upstream deps update — with cron+deps_updated guards on the PubMed cascade to prevent hourly full rebuilds.

### Before
Raw extracts run on schedules. Everything downstream (consolidation, postgres, duckdb) is **manual**.

### After
```
2:00 AM  — Schedules: raw extracts begin
~2:30 AM — eager cascade: consolidation assets auto-materialize (biosample/geo/sra)
~3:30 AM — eager cascade: postgres loads auto-materialize (biosample/geo/sra)

Hourly   — pubmed_sensor → pubmed_raw lands new partition (no immediate cascade)
3:00 AM  — pubmed_parquet runs IF any new pubmed_raw partition since last cron tick
4:00 AM  — pubmed_postgres runs IF pubmed_parquet refreshed
5:00 AM  — omicidx_duckdb runs IF any consolidated parquet refreshed
```

### Changes

| Asset layer | Condition | Count |
|---|---|---|
| Raw (schedules/sensors) | no change | 7 |
| Consolidation — daily upstreams | `eager()` | 9 |
| Consolidation — hourly PubMed upstream | `on_cron("0 3 * * *") & any_deps_updated()` | 1 (`pubmed_parquet`) |
| Consolidation — no deps | `on_cron("0 3 * * *")` | 1 (`sra_accessions_parquet`) |
| Postgres serving — daily | `eager()` | 9 |
| Postgres serving — gated to daily | `on_cron("0 4 * * *") & any_deps_updated()` | 1 (`pubmed_postgres`) |
| DuckDB build | `on_cron("0 5 * * *") & any_deps_updated()` | 1 (`omicidx_duckdb`) |
| **Total automated** | | **22 assets** |

### Why the cron+deps_updated pattern on three assets

PubMed lands hourly via the file sensor. With pure `eager()`, every new PubMed file would trigger a full historical PubMed parquet rebuild (gigabytes), then a full A/B Postgres reload, then a full DuckDB rebuild + S3 upload — every hour. That cascade is too expensive to run more than once per day.

`on_cron("0 N * * *") & any_deps_updated()` says: "fire at the cron tick, but only if at least one upstream actually has new content since the last build." Times are staggered (03 → 04 → 05 UTC) so each downstream finds its dep settled. Documented in detail at `docs/src/content/docs/contributing/automation-cadence.md` (PR #77).

### Also
- Added `AutomationConditionSensorDefinition` with `default_status=RUNNING`
- Fixed `from __future__ import annotations` bug in `sql.py` (#69)
- Filed #73 for `omicidx_duckdb`'s fixed-DB-path concurrent-run safety (orthogonal; daily cadence makes overlap unlikely)

### Failure isolation
Each asset evaluates independently. If `biosample_raw` fails, only `biosample_parquet` → `biosample_postgres` is blocked. Other entity chains proceed normally.

## Test plan
- [x] CI: lint, format, 87 tests pass
- [x] Definitions load with all 33 assets, conditions verified
- [x] Rebuild dagster container, automation sensor appears RUNNING in UI
- [x] Manual materialize `bioproject_raw`, eager cascade triggers `bioproject_parquet` → `bioproject_postgres`
- [ ] Let daily schedule run overnight, verify end-to-end cascade including 03/04/05 UTC PubMed gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)