### PR TITLE
feat(api): SRA hierarchy routes (#100)

### DIFF
--- a/packages/omicidx-api/src/omicidx/api/routers/sra.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/sra.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from omicidx.api.config import settings
@@ -7,16 +7,23 @@ from omicidx.api.db import get_session
 from omicidx.api.models import SraExperiment, SraRun, SraSample, SraStudy
 from omicidx.api.pagination import decode_cursor, encode_cursor
 from omicidx.api.schemas.envelope import (
+    CollectionRelationship,
     Relationship,
     build_item_response,
     build_list_response,
 )
-from sqlalchemy import select
+from sqlalchemy import distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
 
 Session = Annotated[AsyncSession, Depends(get_session)]
+
+Hydrate = Literal["ids", "summary"]
+
+
+def _id_only(accession: str) -> dict[str, str]:
+    return {"accession": accession}
 
 
 # -- Studies -------------------------------------------------------------------
@@ -28,11 +35,20 @@ async def get_study(accession: str, session: Session):
     if not row:
         raise HTTPException(404, detail=f"SRA study {accession} not found")
 
-    relationships = {}
+    relationships: dict[str, Relationship | CollectionRelationship] = {}
     if row.bioproject:
         relationships["bioproject"] = Relationship(
             accession=row.bioproject, href=f"/v1/bioproject/{row.bioproject}"
         )
+    relationships["samples"] = CollectionRelationship(
+        href=f"/v1/sra/studies/{accession}/samples"
+    )
+    relationships["experiments"] = CollectionRelationship(
+        href=f"/v1/sra/studies/{accession}/experiments"
+    )
+    relationships["runs"] = CollectionRelationship(
+        href=f"/v1/sra/studies/{accession}/runs"
+    )
 
     return build_item_response(item=row.data, relationships=relationships or None)
 
@@ -86,11 +102,17 @@ async def get_sample(accession: str, session: Session):
     if not row:
         raise HTTPException(404, detail=f"SRA sample {accession} not found")
 
-    relationships = {}
+    relationships: dict[str, Relationship | CollectionRelationship] = {}
     if row.biosample:
         relationships["biosample"] = Relationship(
             accession=row.biosample, href=f"/v1/biosample/{row.biosample}"
         )
+    relationships["experiments"] = CollectionRelationship(
+        href=f"/v1/sra/samples/{accession}/experiments"
+    )
+    relationships["runs"] = CollectionRelationship(
+        href=f"/v1/sra/samples/{accession}/runs"
+    )
 
     return build_item_response(item=row.data, relationships=relationships or None)
 
@@ -138,7 +160,7 @@ async def get_experiment(accession: str, session: Session):
     if not row:
         raise HTTPException(404, detail=f"SRA experiment {accession} not found")
 
-    relationships = {}
+    relationships: dict[str, Relationship | CollectionRelationship] = {}
     if row.sample_accession:
         relationships["sample"] = Relationship(
             accession=row.sample_accession,
@@ -149,6 +171,9 @@ async def get_experiment(accession: str, session: Session):
             accession=row.study_accession,
             href=f"/v1/sra/studies/{row.study_accession}",
         )
+    relationships["runs"] = CollectionRelationship(
+        href=f"/v1/sra/experiments/{accession}/runs"
+    )
 
     return build_item_response(item=row.data, relationships=relationships or None)
 
@@ -234,6 +259,317 @@ async def list_runs(
     return build_list_response(
         items=items,
         path="/v1/sra/runs",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+# -- Hierarchy: study children -------------------------------------------------
+
+
+@router.get("/studies/{accession}/samples")
+async def list_study_samples(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Distinct sample accessions linked to the study via experiments."""
+    sample_subq = (
+        select(distinct(SraExperiment.sample_accession).label("accession"))
+        .where(
+            SraExperiment.study_accession == accession,
+            SraExperiment.sample_accession.is_not(None),
+        )
+        .subquery()
+    )
+
+    if hydrate == "summary":
+        stmt = (
+            select(SraSample)
+            .join(sample_subq, SraSample.accession == sample_subq.c.accession)
+            .order_by(SraSample.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraSample.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        stmt = (
+            select(sample_subq.c.accession)
+            .order_by(sample_subq.c.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(sample_subq.c.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/studies/{accession}/samples",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+@router.get("/studies/{accession}/experiments")
+async def list_study_experiments(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Experiments belonging to the study (1:N via study_accession)."""
+    if hydrate == "summary":
+        stmt = (
+            select(SraExperiment)
+            .where(SraExperiment.study_accession == accession)
+            .order_by(SraExperiment.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraExperiment.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        stmt = (
+            select(SraExperiment.accession)
+            .where(SraExperiment.study_accession == accession)
+            .order_by(SraExperiment.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraExperiment.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/studies/{accession}/experiments",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+@router.get("/studies/{accession}/runs")
+async def list_study_runs(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Runs belonging to the study (transitive via experiment)."""
+    base = (
+        select(SraRun if hydrate == "summary" else SraRun.accession)
+        .join(SraExperiment, SraRun.experiment_accession == SraExperiment.accession)
+        .where(SraExperiment.study_accession == accession)
+        .order_by(SraRun.accession)
+        .limit(limit + 1)
+    )
+    if cursor:
+        base = base.where(SraRun.accession > decode_cursor(cursor).after)
+
+    result = await session.execute(base)
+
+    if hydrate == "summary":
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/studies/{accession}/runs",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+# -- Hierarchy: sample children ------------------------------------------------
+
+
+@router.get("/samples/{accession}/experiments")
+async def list_sample_experiments(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Experiments derived from the sample (1:N via sample_accession)."""
+    if hydrate == "summary":
+        stmt = (
+            select(SraExperiment)
+            .where(SraExperiment.sample_accession == accession)
+            .order_by(SraExperiment.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraExperiment.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        stmt = (
+            select(SraExperiment.accession)
+            .where(SraExperiment.sample_accession == accession)
+            .order_by(SraExperiment.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraExperiment.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/samples/{accession}/experiments",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+@router.get("/samples/{accession}/runs")
+async def list_sample_runs(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Runs derived from the sample (transitive via experiment)."""
+    base = (
+        select(SraRun if hydrate == "summary" else SraRun.accession)
+        .join(SraExperiment, SraRun.experiment_accession == SraExperiment.accession)
+        .where(SraExperiment.sample_accession == accession)
+        .order_by(SraRun.accession)
+        .limit(limit + 1)
+    )
+    if cursor:
+        base = base.where(SraRun.accession > decode_cursor(cursor).after)
+
+    result = await session.execute(base)
+
+    if hydrate == "summary":
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/samples/{accession}/runs",
+        limit=limit,
+        next_cursor=next_cursor,
+        cursor_param=cursor,
+    )
+
+
+# -- Hierarchy: experiment children --------------------------------------------
+
+
+@router.get("/experiments/{accession}/runs")
+async def list_experiment_runs(
+    accession: str,
+    session: Session,
+    hydrate: Hydrate = "ids",
+    cursor: str | None = None,
+    limit: Annotated[
+        int, Query(ge=1, le=settings.max_page_size)
+    ] = settings.default_page_size,
+):
+    """Runs for an experiment (1:N via experiment_accession)."""
+    if hydrate == "summary":
+        stmt = (
+            select(SraRun)
+            .where(SraRun.experiment_accession == accession)
+            .order_by(SraRun.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraRun.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+        has_next = len(rows) > limit
+        items = [r.data for r in rows[:limit]]
+        next_cursor = (
+            encode_cursor(rows[limit - 1].accession) if has_next else None
+        )
+    else:
+        stmt = (
+            select(SraRun.accession)
+            .where(SraRun.experiment_accession == accession)
+            .order_by(SraRun.accession)
+            .limit(limit + 1)
+        )
+        if cursor:
+            stmt = stmt.where(SraRun.accession > decode_cursor(cursor).after)
+        result = await session.execute(stmt)
+        accs = result.scalars().all()
+        has_next = len(accs) > limit
+        items = [_id_only(a) for a in accs[:limit]]
+        next_cursor = encode_cursor(accs[limit - 1]) if has_next else None
+
+    return build_list_response(
+        items=items,
+        path=f"/v1/sra/experiments/{accession}/runs",
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,

--- a/packages/omicidx-api/src/omicidx/api/routers/sra.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/sra.py
@@ -301,9 +301,7 @@ async def list_study_samples(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         stmt = (
             select(sample_subq.c.accession)
@@ -351,9 +349,7 @@ async def list_study_experiments(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         stmt = (
             select(SraExperiment.accession)
@@ -405,9 +401,7 @@ async def list_study_runs(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         accs = result.scalars().all()
         has_next = len(accs) > limit
@@ -450,9 +444,7 @@ async def list_sample_experiments(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         stmt = (
             select(SraExperiment.accession)
@@ -504,9 +496,7 @@ async def list_sample_runs(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         accs = result.scalars().all()
         has_next = len(accs) > limit
@@ -549,9 +539,7 @@ async def list_experiment_runs(
         rows = result.scalars().all()
         has_next = len(rows) > limit
         items = [r.data for r in rows[:limit]]
-        next_cursor = (
-            encode_cursor(rows[limit - 1].accession) if has_next else None
-        )
+        next_cursor = encode_cursor(rows[limit - 1].accession) if has_next else None
     else:
         stmt = (
             select(SraRun.accession)

--- a/packages/omicidx-api/src/omicidx/api/routers/sra.py
+++ b/packages/omicidx-api/src/omicidx/api/routers/sra.py
@@ -322,6 +322,7 @@ async def list_study_samples(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )
 
 
@@ -371,6 +372,7 @@ async def list_study_experiments(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )
 
 
@@ -414,6 +416,7 @@ async def list_study_runs(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )
 
 
@@ -466,6 +469,7 @@ async def list_sample_experiments(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )
 
 
@@ -509,6 +513,7 @@ async def list_sample_runs(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )
 
 
@@ -561,4 +566,5 @@ async def list_experiment_runs(
         limit=limit,
         next_cursor=next_cursor,
         cursor_param=cursor,
+        extra_params={"hydrate": hydrate},
     )

--- a/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
+++ b/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
@@ -1,4 +1,5 @@
 from typing import Any, Generic, TypeVar
+from urllib.parse import urlencode
 
 from pydantic import BaseModel
 
@@ -51,16 +52,28 @@ def build_list_response(
     next_cursor: str | None,
     prev_cursor: str | None = None,
     cursor_param: str | None = None,
+    extra_params: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Build a list envelope dict from query results."""
-    base = path.split("?")[0]
+    """Build a list envelope dict from query results.
 
-    next_link = f"{base}?cursor={next_cursor}&limit={limit}" if next_cursor else None
-    self_link = (
-        f"{base}?cursor={cursor_param}&limit={limit}"
-        if cursor_param
-        else f"{base}?limit={limit}"
+    ``extra_params`` is merged into both ``links.self`` and ``links.next``
+    so non-cursor query params (e.g. ``hydrate``) round-trip across pages.
+    Values that are None are dropped.
+    """
+    base = path.split("?")[0]
+    carry = {k: v for k, v in (extra_params or {}).items() if v is not None}
+
+    def _qs(*pairs: tuple[str, str | int | None]) -> str:
+        params = [(k, str(v)) for k, v in pairs if v is not None]
+        params.extend(carry.items())
+        return urlencode(params)
+
+    next_link = (
+        f"{base}?{_qs(('cursor', next_cursor), ('limit', limit))}"
+        if next_cursor
+        else None
     )
+    self_link = f"{base}?{_qs(('cursor', cursor_param), ('limit', limit))}"
 
     return {
         "data": items,

--- a/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
+++ b/packages/omicidx-api/src/omicidx/api/schemas/envelope.py
@@ -26,6 +26,12 @@ class Relationship(BaseModel):
     href: str
 
 
+class CollectionRelationship(BaseModel):
+    """A relationship pointing at a paginated sub-resource collection."""
+
+    href: str
+
+
 class ListResponse(BaseModel, Generic[T]):
     data: list[T]
     meta: Meta
@@ -34,7 +40,7 @@ class ListResponse(BaseModel, Generic[T]):
 
 class ItemResponse(BaseModel, Generic[T]):
     data: T
-    relationships: dict[str, Relationship] | None = None
+    relationships: dict[str, Relationship | CollectionRelationship] | None = None
 
 
 def build_list_response(
@@ -76,10 +82,12 @@ def build_list_response(
 def build_item_response(
     *,
     item: dict[str, Any],
-    relationships: dict[str, Relationship] | None = None,
+    relationships: dict[str, Relationship | CollectionRelationship] | None = None,
 ) -> dict[str, Any]:
     """Build a single-item envelope dict."""
     result: dict[str, Any] = {"data": item}
     if relationships:
-        result["relationships"] = {k: v.model_dump() for k, v in relationships.items()}
+        result["relationships"] = {
+            k: v.model_dump(exclude_none=True) for k, v in relationships.items()
+        }
     return result

--- a/packages/omicidx-api/tests/test_sra_hierarchy.py
+++ b/packages/omicidx-api/tests/test_sra_hierarchy.py
@@ -54,7 +54,11 @@ def test_study_samples_ids_default():
         ]
         assert body["meta"]["count"] == 3
         assert body["meta"]["cursor"]["next"] is None
-        assert body["links"]["self"] == "/v1/sra/studies/SRP123/samples?limit=10"
+        self_link = body["links"]["self"]
+        assert self_link.startswith("/v1/sra/studies/SRP123/samples?")
+        assert "limit=10" in self_link
+        # hydrate round-trips into the self link so following pages stay in mode
+        assert "hydrate=ids" in self_link
     finally:
         _clear_overrides()
 
@@ -70,6 +74,27 @@ def test_study_samples_pagination_emits_next_cursor():
         next_cursor = body["meta"]["cursor"]["next"]
         assert next_cursor is not None
         assert decode_cursor(next_cursor).after == "SRS2"
+    finally:
+        _clear_overrides()
+
+
+def test_study_samples_summary_preserves_hydrate_in_pagination_links():
+    """hydrate=summary must round-trip into both self and next links."""
+    rows = [
+        SimpleNamespace(accession=f"SRS{i}", data={"accession": f"SRS{i}"})
+        for i in range(3)  # limit+1 → has_next
+    ]
+    _override_session([rows])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/samples?hydrate=summary&limit=2")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["meta"]["cursor"]["next"] is not None
+        # Both self and next must carry hydrate=summary
+        assert "hydrate=summary" in body["links"]["self"]
+        assert "hydrate=summary" in body["links"]["next"]
+        # And the cursor in next is the encoded last-included accession
+        assert "cursor=" in body["links"]["next"]
     finally:
         _clear_overrides()
 

--- a/packages/omicidx-api/tests/test_sra_hierarchy.py
+++ b/packages/omicidx-api/tests/test_sra_hierarchy.py
@@ -1,0 +1,281 @@
+"""Routing/shape tests for the SRA hierarchy endpoints (#100).
+
+These mock the async session, so they exercise routing, query-param parsing,
+response envelope, and cursor round-tripping — not the underlying SQL.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+from omicidx.api.db import get_session
+from omicidx.api.main import app
+from omicidx.api.pagination import decode_cursor, encode_cursor
+
+client = TestClient(app)
+
+
+def _override_session(execute_side_effect):
+    """Install a session whose execute() returns a result with the given scalars."""
+    sess = AsyncMock()
+
+    def _execute(_stmt):
+        scalars = execute_side_effect.pop(0) if execute_side_effect else []
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = scalars
+        return result
+
+    sess.execute = AsyncMock(side_effect=_execute)
+
+    async def override():
+        yield sess
+
+    app.dependency_overrides[get_session] = override
+    return sess
+
+
+def _clear_overrides():
+    app.dependency_overrides.clear()
+
+
+# -- /studies/{srp}/samples ----------------------------------------------------
+
+
+def test_study_samples_ids_default():
+    _override_session([["SRS1", "SRS2", "SRS3"]])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/samples?limit=10")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["data"] == [
+            {"accession": "SRS1"},
+            {"accession": "SRS2"},
+            {"accession": "SRS3"},
+        ]
+        assert body["meta"]["count"] == 3
+        assert body["meta"]["cursor"]["next"] is None
+        assert body["links"]["self"] == "/v1/sra/studies/SRP123/samples?limit=10"
+    finally:
+        _clear_overrides()
+
+
+def test_study_samples_pagination_emits_next_cursor():
+    # limit+1 returned → has_next is true; cursor encodes the limit-th accession
+    _override_session([["SRS1", "SRS2", "SRS3"]])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/samples?limit=2")
+        assert r.status_code == 200
+        body = r.json()
+        assert [d["accession"] for d in body["data"]] == ["SRS1", "SRS2"]
+        next_cursor = body["meta"]["cursor"]["next"]
+        assert next_cursor is not None
+        assert decode_cursor(next_cursor).after == "SRS2"
+    finally:
+        _clear_overrides()
+
+
+def test_study_samples_summary_returns_full_rows():
+    rows = [
+        SimpleNamespace(
+            accession="SRS1",
+            data={"accession": "SRS1", "organism": "Homo sapiens"},
+        ),
+        SimpleNamespace(
+            accession="SRS2",
+            data={"accession": "SRS2", "organism": "Mus musculus"},
+        ),
+    ]
+    _override_session([rows])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/samples?hydrate=summary")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["data"][0]["organism"] == "Homo sapiens"
+        assert body["data"][1]["organism"] == "Mus musculus"
+    finally:
+        _clear_overrides()
+
+
+def test_study_samples_empty():
+    _override_session([[]])
+    try:
+        r = client.get("/v1/sra/studies/SRP_NONE/samples")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["data"] == []
+        assert body["meta"]["count"] == 0
+    finally:
+        _clear_overrides()
+
+
+# -- /studies/{srp}/experiments ------------------------------------------------
+
+
+def test_study_experiments_ids():
+    _override_session([["SRX1", "SRX2"]])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/experiments")
+        assert r.status_code == 200
+        assert [d["accession"] for d in r.json()["data"]] == ["SRX1", "SRX2"]
+    finally:
+        _clear_overrides()
+
+
+# -- /studies/{srp}/runs -------------------------------------------------------
+
+
+def test_study_runs_ids():
+    _override_session([["SRR1", "SRR2"]])
+    try:
+        r = client.get("/v1/sra/studies/SRP123/runs")
+        assert r.status_code == 200
+        assert [d["accession"] for d in r.json()["data"]] == ["SRR1", "SRR2"]
+    finally:
+        _clear_overrides()
+
+
+def test_study_runs_cursor_round_trip():
+    cursor = encode_cursor("SRR123")
+    _override_session([["SRR456"]])
+    try:
+        r = client.get(f"/v1/sra/studies/SRP123/runs?cursor={cursor}&limit=25")
+        assert r.status_code == 200
+        body = r.json()
+        # cursor_param is preserved in the self link
+        assert f"cursor={cursor}" in body["links"]["self"]
+    finally:
+        _clear_overrides()
+
+
+# -- /samples/{srs}/experiments ------------------------------------------------
+
+
+def test_sample_experiments_ids():
+    _override_session([["SRX1", "SRX2"]])
+    try:
+        r = client.get("/v1/sra/samples/SRS123/experiments")
+        assert r.status_code == 200
+        assert [d["accession"] for d in r.json()["data"]] == ["SRX1", "SRX2"]
+    finally:
+        _clear_overrides()
+
+
+# -- /samples/{srs}/runs -------------------------------------------------------
+
+
+def test_sample_runs_ids():
+    _override_session([["SRR1"]])
+    try:
+        r = client.get("/v1/sra/samples/SRS123/runs")
+        assert r.status_code == 200
+        assert r.json()["data"] == [{"accession": "SRR1"}]
+    finally:
+        _clear_overrides()
+
+
+# -- /experiments/{srx}/runs ---------------------------------------------------
+
+
+def test_experiment_runs_ids():
+    _override_session([["SRR1", "SRR2", "SRR3"]])
+    try:
+        r = client.get("/v1/sra/experiments/SRX123/runs?limit=2")
+        assert r.status_code == 200
+        body = r.json()
+        assert [d["accession"] for d in body["data"]] == ["SRR1", "SRR2"]
+        assert body["meta"]["cursor"]["next"] is not None
+    finally:
+        _clear_overrides()
+
+
+def test_experiment_runs_summary():
+    rows = [
+        SimpleNamespace(
+            accession="SRR1",
+            data={"accession": "SRR1", "total_spots": 1000},
+        ),
+    ]
+    _override_session([rows])
+    try:
+        r = client.get("/v1/sra/experiments/SRX123/runs?hydrate=summary")
+        assert r.status_code == 200
+        assert r.json()["data"][0]["total_spots"] == 1000
+    finally:
+        _clear_overrides()
+
+
+# -- entity GET relationships block --------------------------------------------
+
+
+def test_get_study_includes_collection_relationships():
+    row = SimpleNamespace(
+        accession="SRP123",
+        bioproject="PRJNA123",
+        data={"accession": "SRP123", "title": "Test study"},
+    )
+    sess = AsyncMock()
+    sess.get = AsyncMock(return_value=row)
+
+    async def override():
+        yield sess
+
+    app.dependency_overrides[get_session] = override
+    try:
+        r = client.get("/v1/sra/studies/SRP123")
+        assert r.status_code == 200
+        rels = r.json()["relationships"]
+        assert rels["bioproject"]["accession"] == "PRJNA123"
+        assert rels["samples"]["href"] == "/v1/sra/studies/SRP123/samples"
+        assert rels["experiments"]["href"] == "/v1/sra/studies/SRP123/experiments"
+        assert rels["runs"]["href"] == "/v1/sra/studies/SRP123/runs"
+        # CollectionRelationship omits accession
+        assert "accession" not in rels["samples"]
+    finally:
+        _clear_overrides()
+
+
+def test_get_sample_includes_collection_relationships():
+    row = SimpleNamespace(
+        accession="SRS123",
+        biosample="SAMN123",
+        data={"accession": "SRS123"},
+    )
+    sess = AsyncMock()
+    sess.get = AsyncMock(return_value=row)
+
+    async def override():
+        yield sess
+
+    app.dependency_overrides[get_session] = override
+    try:
+        r = client.get("/v1/sra/samples/SRS123")
+        rels = r.json()["relationships"]
+        assert rels["biosample"]["accession"] == "SAMN123"
+        assert rels["experiments"]["href"] == "/v1/sra/samples/SRS123/experiments"
+        assert rels["runs"]["href"] == "/v1/sra/samples/SRS123/runs"
+    finally:
+        _clear_overrides()
+
+
+def test_get_experiment_includes_runs_collection():
+    row = SimpleNamespace(
+        accession="SRX123",
+        sample_accession="SRS1",
+        study_accession="SRP1",
+        data={"accession": "SRX123"},
+    )
+    sess = AsyncMock()
+    sess.get = AsyncMock(return_value=row)
+
+    async def override():
+        yield sess
+
+    app.dependency_overrides[get_session] = override
+    try:
+        r = client.get("/v1/sra/experiments/SRX123")
+        rels = r.json()["relationships"]
+        assert rels["sample"]["accession"] == "SRS1"
+        assert rels["study"]["accession"] == "SRP1"
+        assert rels["runs"]["href"] == "/v1/sra/experiments/SRX123/runs"
+    finally:
+        _clear_overrides()


### PR DESCRIPTION
## Summary

Adds 6 paginated sub-resource collection endpoints under `/v1/sra` so clients can walk the SRA hierarchy without scanning entity tables:

- `GET /studies/{srp}/samples` (DISTINCT samples via experiments)
- `GET /studies/{srp}/experiments`
- `GET /studies/{srp}/runs` (transitive via experiments)
- `GET /samples/{srs}/experiments`
- `GET /samples/{srs}/runs` (transitive via experiments)
- `GET /experiments/{srx}/runs`

All routes share the existing keyset cursor and accept `?hydrate=ids` (default; accession-only payload) or `?hydrate=summary` (full row data from the entity dim table).

A new `CollectionRelationship` envelope schema is added for sub-resource pointers (href only, no accession). Entity GET responses (`/v1/sra/studies/{srp}`, `/samples/{srs}`, `/experiments/{srx}`) now include collection relationship blocks pointing at their children.

Each route relies on existing indexes: `sra_experiment.study_accession`, `sra_experiment.sample_accession`, `sra_run.experiment_accession`.

## Test plan

- [x] 14 new router/shape tests in `test_sra_hierarchy.py` (mocked sessions): hydrate=ids/summary, cursor round-trip, empty results, relationships block on entity GETs
- [x] All 37 API tests pass locally
- [ ] Smoke against deployed API once merged: `curl https://api-omicidx.cancerdatasci.org/v1/sra/studies/SRP000001/runs?hydrate=ids&limit=5`

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)