### PR TITLE
feat(prefect): port ETL from Dagster to Prefect with semaphore-file partitioning

### DIFF
--- a/packages/omicidx-prefect/Dockerfile
+++ b/packages/omicidx-prefect/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the workspace so uv can resolve workspace refs
+COPY pyproject.toml /opt/prefect/workspace/pyproject.toml
+COPY packages/omicidx-parsers /opt/prefect/workspace/packages/omicidx-parsers
+COPY packages/omicidx-prefect /opt/prefect/workspace/packages/omicidx-prefect
+
+WORKDIR /opt/prefect/omicidx
+
+# Symlink for the prefect.yaml `pull` step
+RUN ln -s /opt/prefect/workspace/packages/omicidx-prefect/src /opt/prefect/omicidx/src \
+    && ln -s /opt/prefect/workspace/packages/omicidx-prefect/prefect.yaml /opt/prefect/omicidx/prefect.yaml
+
+RUN pip install --no-cache-dir \
+    /opt/prefect/workspace/packages/omicidx-parsers \
+    /opt/prefect/workspace/packages/omicidx-prefect
+
+# Default to a process-style worker; override with `command:` in compose.
+CMD ["prefect", "worker", "start", "--pool", "default", "--type", "process"]

--- a/packages/omicidx-prefect/README.md
+++ b/packages/omicidx-prefect/README.md
@@ -1,0 +1,174 @@
+# omicidx-prefect
+
+Prefect 3 flows for OmicIDX ETL — the same pipeline as `omicidx-dagster`,
+re-implemented on top of Prefect with **semaphore-file partitioning** in
+place of Dagster's built-in partition state.
+
+## Why semaphore files
+
+Dagster tracks partition completion in its own Postgres-backed event
+log. That ties the pipeline's "what's done" state to the orchestrator's
+metadata DB. Prefect doesn't model partitions natively, and we don't
+want to lean on Prefect's run history for it either.
+
+Instead, each partition writes a small JSON marker — a *semaphore* — to
+the same storage bucket as the data:
+
+```
+{PUBLISH_ROOT}/_semaphores/
+  sra/
+    study/
+      2024-09-12_Full.json
+      2024-09-13_Incremental.json
+      ...
+    sample/...
+    experiment/...
+    run/...
+  geo/
+    2024-01.json
+    2024-02.json
+    ...
+  pubmed/
+    pubmed25n0001.json
+    pubmed25n0002.json
+    ...
+  biosample/
+    2024-09-13.json
+  bioproject/
+    2024-09-13.json
+  ebi_biosample/
+    2024-09-13.json
+    ...
+  sra_accessions_etag/
+    latest.json   # stores the most-recently-seen ETag
+```
+
+Each semaphore file is `~200 bytes` of JSON: completion timestamp +
+caller-supplied metadata (row_count, output_path, etc.).
+
+**Rules:**
+
+- A flow processes a partition only if its semaphore is missing (or
+  `force=True` is passed).
+- After the partition output is durably written, the flow writes the
+  semaphore.
+- Backfills are "delete the semaphores you want to redo, then re-run":
+
+  ```bash
+  omicidx-prefect semaphores clear sra/study --all          # whole entity
+  omicidx-prefect semaphores clear pubmed pubmed25n0042     # one file
+  ```
+- Inspect with `omicidx-prefect semaphores list <namespace>` and
+  `omicidx-prefect semaphores show <namespace> <key>`.
+
+The current-period partition (GEO current month, EBI current day) is
+always re-run by default, because upstream data accumulates within the
+period. Pass `rerun_current_month=False` / `rerun_current_day=False`
+to skip even those.
+
+## Layout
+
+```
+packages/omicidx-prefect/
+├── pyproject.toml
+├── prefect.yaml             # deployments (schedules)
+├── Dockerfile               # worker image
+├── docker-compose.yml       # prefect server + db + worker
+├── src/omicidx/prefect/
+│   ├── config.py            # Settings + storage / duckdb / postgres helpers
+│   ├── semaphore.py         # SemaphoreStore
+│   ├── cli.py               # `omicidx-prefect` operator CLI
+│   ├── flows/
+│   │   ├── sra.py
+│   │   ├── geo.py
+│   │   ├── biosample.py
+│   │   ├── pubmed.py
+│   │   ├── ebi_biosample.py
+│   │   ├── consolidate.py
+│   │   ├── postgres.py
+│   │   ├── sql.py
+│   │   └── main.py          # daily_pipeline_flow
+│   └── sql/                 # DuckDB view SQL (020–050)
+└── tests/
+```
+
+## Quick start
+
+```bash
+# 1) From the workspace root
+uv sync
+
+# 2) Run a flow directly (no scheduler)
+uv run omicidx-prefect run sra
+uv run omicidx-prefect run geo --start-month 2024-01
+uv run omicidx-prefect run pubmed
+uv run omicidx-prefect run daily
+
+# 3) Inspect semaphores
+uv run omicidx-prefect semaphores list sra/study
+uv run omicidx-prefect semaphores show pubmed pubmed25n0001
+```
+
+## Self-hosted Prefect
+
+```bash
+cd packages/omicidx-prefect
+
+# .env supplies the same vars as the dagster package
+cp .env.example .env  # (create one if you haven't)
+
+docker compose up -d --build
+# UI at http://localhost:4200
+
+docker compose exec worker prefect deploy --all
+docker compose exec worker prefect deployment ls
+```
+
+## Mapping from Dagster
+
+| Dagster concept                  | Prefect equivalent here                                |
+|----------------------------------|--------------------------------------------------------|
+| `@dg.asset`                      | `@task` inside a `@flow`                               |
+| `dg.Definitions(...)`            | `prefect.yaml` (deployments)                           |
+| `dg.ScheduleDefinition`          | `schedules:` in `prefect.yaml`                         |
+| `StaticPartitionsDefinition`     | semaphore namespace per static value                   |
+| `MonthlyPartitionsDefinition`    | `_enumerate_months()` + semaphore per `YYYY-MM` key    |
+| `DailyPartitionsDefinition`      | `_enumerate_days()` + semaphore per `YYYY-MM-DD` key   |
+| `DynamicPartitionsDefinition`    | flow lists the source itself, gates by semaphore       |
+| `OmicidxStorage` resource        | `config.get_upath()` / `config.get_duckdb_path()`      |
+| `DuckDBResource` resource        | `config.get_duckdb_connection()`                       |
+| `PostgresResource` resource      | `config.execute_postgres_sql()` / `attach_postgres()`  |
+| ETag-change sensor               | `sra_accessions_if_changed` task (semaphore stores ETag)|
+| `dg.AutomationCondition`         | sequential subflows in `daily_pipeline_flow`           |
+
+## Environment variables
+
+Same as omicidx-dagster:
+
+```
+PUBLISH_ROOT=s3://omicidx
+S3_ACCESS_KEY_ID=...
+S3_SECRET_ACCESS_KEY=...
+S3_ENDPOINT=https://....r2.cloudflarestorage.com
+S3_REGION=auto
+S3_URL_STYLE=path
+POSTGRES_URI=postgresql://omicidx@host:5432/omicidx
+```
+
+## Tests
+
+```bash
+uv run pytest packages/omicidx-prefect/tests/
+```
+
+## Operational notes
+
+- **Concurrency**: each flow uses `ThreadPoolTaskRunner(max_workers=...)`.
+  Tune per flow if a source is rate-limited (GEO uses 2 to be polite to
+  the eutils API).
+- **Retries**: raw extract tasks have `retries=2, retry_delay_seconds=60`;
+  consolidate / postgres / sql tasks have `retries=1, retry_delay_seconds=60`.
+- **Failure semantics**: if a partition task fails after retries, the
+  semaphore is **not** written — the next run picks it up automatically.
+- **Force re-run**: every flow accepts a `force: bool = False` parameter
+  that bypasses semaphores.

--- a/packages/omicidx-prefect/docker-compose.yml
+++ b/packages/omicidx-prefect/docker-compose.yml
@@ -1,0 +1,79 @@
+# Self-hosted Prefect server + worker for omicidx ETL.
+#
+# Bring up:
+#   docker compose up -d --build
+#
+# Apply deployments (one-time, after the server is healthy):
+#   docker compose exec worker prefect deploy --all
+#
+# UI is exposed at http://localhost:4200 (PREFECT_API_URL).
+
+services:
+  prefect-db:
+    image: postgres:16
+    container_name: omicidx-prefect-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: prefect
+      POSTGRES_PASSWORD: ${PREFECT_DB_PASSWORD:-prefect}
+      POSTGRES_DB: prefect
+    volumes:
+      - prefect-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prefect"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  prefect-server:
+    image: prefecthq/prefect:3-latest
+    container_name: omicidx-prefect-server
+    restart: unless-stopped
+    depends_on:
+      prefect-db:
+        condition: service_healthy
+    ports:
+      - "4200:4200"
+    environment:
+      PREFECT_SERVER_API_HOST: "0.0.0.0"
+      PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:${PREFECT_DB_PASSWORD:-prefect}@prefect-db:5432/prefect
+      PREFECT_UI_API_URL: http://localhost:4200/api
+    command: ["prefect", "server", "start", "--host", "0.0.0.0"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', 4200), timeout=5)"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 5
+
+  worker:
+    build:
+      context: ../..
+      dockerfile: packages/omicidx-prefect/Dockerfile
+    container_name: omicidx-prefect-worker
+    restart: unless-stopped
+    depends_on:
+      prefect-server:
+        condition: service_healthy
+    environment:
+      PREFECT_API_URL: http://prefect-server:4200/api
+      # R2/S3 storage
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
+      S3_REGION: ${S3_REGION:-auto}
+      S3_URL_STYLE: ${S3_URL_STYLE:-path}
+      PUBLISH_ROOT: ${PUBLISH_ROOT:-s3://omicidx}
+      # API-serving Postgres
+      POSTGRES_URI: ${POSTGRES_URI:-postgresql://omicidx@pg_duckdb_18:5432/omicidx}
+    command:
+      - prefect
+      - worker
+      - start
+      - --pool
+      - default
+      - --type
+      - process
+
+volumes:
+  prefect-db-data:

--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -1,0 +1,96 @@
+# Prefect deployment manifest for omicidx ETL.
+#
+# Apply with:
+#   prefect deploy --all
+#
+# Schedules mirror the Dagster setup:
+#   - daily-pipeline:           02:00 UTC (full extract → consolidate → load → build)
+#   - hourly-pubmed:            poll FTP for new PubMed files
+#   - hourly-sra-accessions:    check SRA_Accessions.tab ETag, reload if changed
+#   - geo-monthly-rerun:        re-extract current month at 06:00 UTC daily
+
+name: omicidx-prefect
+prefect-version: 3.0.0
+
+build: null
+
+push: null
+
+pull:
+  - prefect.deployments.steps.set_working_directory:
+      directory: /opt/prefect/omicidx
+
+deployments:
+  - name: daily-pipeline
+    description: |
+      Full daily ETL: raw extracts (semaphore-gated), consolidation,
+      postgres reload, duckdb build + upload.
+    entrypoint: src/omicidx/prefect/flows/main.py:daily_pipeline_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+    schedules:
+      - cron: "0 2 * * *"
+        timezone: UTC
+        active: true
+    parameters:
+      force: false
+
+  - name: pubmed-extract
+    description: Poll PubMed FTP for new files, extract any missing partitions.
+    entrypoint: src/omicidx/prefect/flows/pubmed.py:pubmed_extract_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+    schedules:
+      - interval: 3600
+        active: true
+
+  - name: sra-accessions-etag
+    description: |
+      Re-ingest SRA_Accessions.tab when its ETag changes. Runs the
+      consolidation flow's etag-gated task in isolation.
+    entrypoint: src/omicidx/prefect/flows/consolidate.py:consolidate_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+    schedules:
+      - interval: 3600
+        active: false  # daily-pipeline covers this; enable for tighter polling
+
+  - name: geo-extract
+    description: |
+      Re-run the GEO monthly extractor (current month always re-fires;
+      historical months skipped if semaphore exists).
+    entrypoint: src/omicidx/prefect/flows/geo.py:geo_extract_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+    schedules:
+      - cron: "0 6 * * *"
+        timezone: UTC
+        active: true
+    parameters:
+      rerun_current_month: true
+      force: false
+
+  - name: consolidate
+    description: Per-entity raw → parquet consolidation.
+    entrypoint: src/omicidx/prefect/flows/consolidate.py:consolidate_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+
+  - name: postgres-load
+    description: Reload every API-serving table from its consolidated parquet.
+    entrypoint: src/omicidx/prefect/flows/postgres.py:postgres_load_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+
+  - name: omicidx-duckdb-build
+    description: Build the published omicidx.duckdb file and upload to R2/S3.
+    entrypoint: src/omicidx/prefect/flows/sql.py:omicidx_duckdb_flow
+    work_pool:
+      name: default
+      work_queue_name: default

--- a/packages/omicidx-prefect/pyproject.toml
+++ b/packages/omicidx-prefect/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "omicidx-prefect"
+version = "0.1.0"
+description = "Prefect flows for OmicIDX ETL pipelines"
+authors = [
+    {name = "Sean Davis", email = "seandavi@gmail.com"},
+]
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "prefect>=3.0",
+    "omicidx-parsers",
+    "pyarrow>=20.0.0",
+    "httpx>=0.28",
+    "orjson>=3.10",
+    "duckdb>=1.4",
+    "sqlglot>=27.0",
+    "universal-pathlib>=0.2.2",
+    "s3fs>=2023.0.0",
+    "tenacity>=8.0",
+    "pubmed-parser @ git+https://github.com/seandavi/pubmed_parser",
+    "polars-lts-cpu>=1.32",
+    "python-dotenv>=1.1",
+    "anyio[trio]>=4.0",
+    "sqlalchemy[asyncio]>=2.0",
+    "asyncpg>=0.30",
+    "python-dateutil>=2.9",
+    "pydantic-settings>=2.0",
+    "click>=8.0",
+]
+
+[project.scripts]
+omicidx-prefect = "omicidx.prefect.cli:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/omicidx"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.uv.sources]
+omicidx-parsers = { workspace = true }

--- a/packages/omicidx-prefect/src/omicidx/prefect/__init__.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/__init__.py
@@ -1,0 +1,7 @@
+"""Prefect flows for OmicIDX ETL pipelines."""
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env", override=False)

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -1,0 +1,149 @@
+"""Command-line helpers for omicidx-prefect.
+
+Most operations go through `prefect deployment run ...`. This CLI
+covers semaphore inspection and ad-hoc local flow runs.
+"""
+
+import click
+from omicidx.prefect.semaphore import SemaphoreStore
+
+
+@click.group()
+def cli() -> None:
+    """omicidx-prefect operator CLI."""
+
+
+@cli.group()
+def semaphores() -> None:
+    """Inspect and clear partition-completion semaphores."""
+
+
+@semaphores.command("list")
+@click.argument("namespace")
+def list_semaphores(namespace: str) -> None:
+    """List completed partition keys for NAMESPACE (e.g. sra/study, geo)."""
+    store = SemaphoreStore(namespace)
+    keys = store.list_keys()
+    click.echo(f"{namespace}: {len(keys)} semaphores")
+    for k in keys:
+        click.echo(f"  {k}")
+
+
+@semaphores.command("show")
+@click.argument("namespace")
+@click.argument("key")
+def show_semaphore(namespace: str, key: str) -> None:
+    """Print the semaphore JSON for NAMESPACE/KEY."""
+    import json
+
+    payload = SemaphoreStore(namespace).read(key)
+    if payload is None:
+        raise click.ClickException(f"No semaphore at {namespace}/{key}")
+    click.echo(json.dumps(payload, indent=2))
+
+
+@semaphores.command("clear")
+@click.argument("namespace")
+@click.argument("key", required=False)
+@click.option("--all", "clear_all", is_flag=True, help="Clear the whole namespace")
+def clear_semaphore(namespace: str, key: str | None, clear_all: bool) -> None:
+    """Clear one semaphore or the whole namespace (with --all)."""
+    store = SemaphoreStore(namespace)
+    if clear_all:
+        n = store.clear_all()
+        click.echo(f"Cleared {n} semaphores in {namespace}")
+        return
+    if not key:
+        raise click.UsageError("Pass KEY or --all")
+    removed = store.clear(key)
+    click.echo(f"{'Cleared' if removed else 'No semaphore at'} {namespace}/{key}")
+
+
+@cli.group()
+def run() -> None:
+    """Run flows locally (no scheduler)."""
+
+
+@run.command("sra")
+@click.option("--force", is_flag=True)
+def run_sra(force: bool) -> None:
+    from omicidx.prefect.flows.sra import sra_extract_flow
+
+    sra_extract_flow(force=force)
+
+
+@run.command("geo")
+@click.option("--start-month", default="2005-01")
+@click.option("--end-month", default=None)
+@click.option("--force", is_flag=True)
+def run_geo(start_month: str, end_month: str | None, force: bool) -> None:
+    from omicidx.prefect.flows.geo import geo_extract_flow
+
+    geo_extract_flow(start_month=start_month, end_month=end_month, force=force)
+
+
+@run.command("biosample")
+@click.option("--force", is_flag=True)
+def run_biosample(force: bool) -> None:
+    from omicidx.prefect.flows.biosample import biosample_extract_flow
+
+    biosample_extract_flow(force=force)
+
+
+@run.command("bioproject")
+@click.option("--force", is_flag=True)
+def run_bioproject(force: bool) -> None:
+    from omicidx.prefect.flows.biosample import bioproject_extract_flow
+
+    bioproject_extract_flow(force=force)
+
+
+@run.command("pubmed")
+@click.option("--force", is_flag=True)
+def run_pubmed(force: bool) -> None:
+    from omicidx.prefect.flows.pubmed import pubmed_extract_flow
+
+    pubmed_extract_flow(force=force)
+
+
+@run.command("ebi-biosample")
+@click.option("--start-day", default="2021-01-01")
+@click.option("--end-day", default=None)
+@click.option("--force", is_flag=True)
+def run_ebi_biosample(start_day: str, end_day: str | None, force: bool) -> None:
+    from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
+
+    ebi_biosample_extract_flow(start_day=start_day, end_day=end_day, force=force)
+
+
+@run.command("consolidate")
+def run_consolidate() -> None:
+    from omicidx.prefect.flows.consolidate import consolidate_flow
+
+    consolidate_flow()
+
+
+@run.command("postgres")
+def run_postgres() -> None:
+    from omicidx.prefect.flows.postgres import postgres_load_flow
+
+    postgres_load_flow()
+
+
+@run.command("duckdb")
+def run_duckdb() -> None:
+    from omicidx.prefect.flows.sql import omicidx_duckdb_flow
+
+    omicidx_duckdb_flow()
+
+
+@run.command("daily")
+@click.option("--force", is_flag=True)
+def run_daily(force: bool) -> None:
+    from omicidx.prefect.flows.main import daily_pipeline_flow
+
+    daily_pipeline_flow(force=force)
+
+
+if __name__ == "__main__":
+    cli()

--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -1,0 +1,173 @@
+"""Configuration for omicidx-prefect.
+
+Mirrors the three Dagster resources (OmicidxStorage, DuckDBResource,
+PostgresResource) as a single pydantic-settings object plus per-domain
+helper functions. Prefect flows pull these from module scope rather than
+injecting them as resource parameters.
+"""
+
+import asyncio
+import re
+from contextlib import contextmanager
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import duckdb
+import sqlglot
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from upath import UPath
+
+
+class Settings(BaseSettings):
+    """Environment-backed configuration.
+
+    Env var names match the Dagster setup so the same .env works for
+    both packages during transition.
+    """
+
+    publish_root: str
+    s3_access_key_id: str
+    s3_secret_access_key: str
+    s3_endpoint: str
+    s3_region: str = "auto"
+    s3_url_style: str = "path"
+    postgres_uri: str | None = None
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+@lru_cache(maxsize=1)
+def settings() -> Settings:
+    return Settings()
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers (ports OmicidxStorage)
+# ---------------------------------------------------------------------------
+
+
+def storage_options() -> dict:
+    s = settings()
+    return {
+        "key": s.s3_access_key_id,
+        "secret": s.s3_secret_access_key,
+        "endpoint_url": s.s3_endpoint,
+        "client_kwargs": {"region_name": s.s3_region},
+    }
+
+
+def get_upath(*parts: str) -> UPath:
+    """Build a UPath under the publish root (for fsspec/UPath operations)."""
+    return UPath(settings().publish_root, *parts, **storage_options())
+
+
+def get_duckdb_path(*parts: str) -> str:
+    """Build an r2:// path for use in DuckDB SQL with the r2 secret."""
+    upath = UPath(settings().publish_root, *parts)
+    return str(upath).replace("s3://", "r2://", 1)
+
+
+# ---------------------------------------------------------------------------
+# DuckDB helpers (ports DuckDBResource)
+# ---------------------------------------------------------------------------
+
+
+def _q(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def get_duckdb_connection(database: str = ":memory:") -> duckdb.DuckDBPyConnection:
+    """Create a DuckDB connection with the R2 secret pre-loaded."""
+    s = settings()
+    con = duckdb.connect(database)
+    con.execute("INSTALL httpfs; LOAD httpfs;")
+    con.execute("SET http_retries = 8;")
+    con.execute("SET http_retry_wait_ms = 1000;")
+    con.execute("SET http_retry_backoff = 2.0;")
+    con.execute("SET http_keep_alive = true;")
+
+    account_id = s.s3_endpoint.replace("https://", "").split(".")[0]
+    sql = f"""
+    CREATE OR REPLACE SECRET r2 (
+        TYPE r2,
+        KEY_ID '{_q(s.s3_access_key_id)}',
+        SECRET '{_q(s.s3_secret_access_key)}',
+        ACCOUNT_ID '{_q(account_id)}'
+    );"""
+    con.execute(sql)
+    return con
+
+
+# ---------------------------------------------------------------------------
+# Postgres helpers (ports PostgresResource)
+# ---------------------------------------------------------------------------
+
+
+def _require_postgres_uri() -> str:
+    uri = settings().postgres_uri
+    if not uri:
+        raise RuntimeError("POSTGRES_URI is not set")
+    return uri
+
+
+def postgres_async_uri() -> str:
+    return _require_postgres_uri().replace(
+        "postgresql://", "postgresql+asyncpg://", 1
+    )
+
+
+def _split_postgres_statements(sql: str) -> list[str]:
+    if not sql.strip():
+        raise ValueError("SQL statement cannot be empty")
+    parsed = [
+        expr.sql(dialect="postgres")
+        for expr in sqlglot.parse(sql, read="postgres")
+        if expr is not None
+    ]
+    if not parsed:
+        raise ValueError(
+            "SQL parsing produced no executable statements "
+            "(may contain only comments/whitespace or be malformed)"
+        )
+    return parsed
+
+
+def execute_postgres_sql(*statements: str) -> None:
+    """Run SQL statements against Postgres via SQLAlchemy async + asyncpg."""
+
+    async def _run() -> None:
+        engine = create_async_engine(postgres_async_uri())
+        async with engine.begin() as conn:
+            for sql in statements:
+                for stmt in _split_postgres_statements(sql):
+                    await conn.execute(text(stmt))
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+@contextmanager
+def attach_postgres(con: duckdb.DuckDBPyConnection, schema: str = "public"):
+    """Attach the configured Postgres database to a DuckDB connection."""
+    uri = _require_postgres_uri()
+    parsed = urlparse(uri)
+    if parsed.scheme != "postgresql" or not parsed.hostname:
+        raise ValueError("POSTGRES_URI must be a valid postgresql:// URI")
+    if any(ch in uri for ch in ("'", ";", "\n", "\r", "\x00")):
+        raise ValueError("POSTGRES_URI contains unsupported characters")
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", schema):
+        raise ValueError("Schema name must be a valid SQL identifier")
+
+    con.execute("INSTALL postgres; LOAD postgres;")
+    con.execute(f"ATTACH '{_q(uri)}' AS pg (TYPE POSTGRES, SCHEMA '{_q(schema)}')")
+    try:
+        yield
+    finally:
+        con.execute("DETACH pg")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/biosample.py
@@ -1,0 +1,189 @@
+"""BioSample and BioProject extract flows.
+
+Neither source is partitioned — each run overwrites the single output
+file. We still emit a semaphore per run (keyed by today's date) so
+operators can see when the last successful run finished.
+"""
+
+import gzip
+import shutil
+import tempfile
+import time
+from datetime import date
+
+import httpx
+import orjson
+import tenacity
+from omicidx.parsers.biosample import BioProjectParser, BioSampleParser
+from omicidx.prefect.config import get_duckdb_connection, get_duckdb_path, get_upath
+from omicidx.prefect.semaphore import SemaphoreStore
+from upath import UPath
+
+from prefect import flow, get_run_logger, task
+
+BIOSAMPLE_URL = "https://ftp.ncbi.nlm.nih.gov/biosample/biosample_set.xml.gz"
+BIOPROJECT_URL = "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml"
+
+
+@tenacity.retry(
+    wait=tenacity.wait_exponential(multiplier=1, min=4, max=30),
+    retry=tenacity.retry_if_exception_type(httpx.RequestError),
+    stop=tenacity.stop_after_attempt(5),
+)
+def _download(url: str, dest: str) -> None:
+    log = get_run_logger()
+    log.info(f"Downloading {url}")
+    with (
+        open(dest, "wb") as f,
+        httpx.stream("GET", url, timeout=120, follow_redirects=True) as response,
+    ):
+        response.raise_for_status()
+        for chunk in response.iter_bytes():
+            f.write(chunk)
+    log.info(f"Download complete: {url}")
+
+
+def _extract_entity(
+    *,
+    url: str,
+    entity: str,
+    parser_class: type,
+    use_gzip_input: bool,
+    output_dir: UPath,
+) -> dict:
+    log = get_run_logger()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "data.jsonl.gz"
+
+    start = time.time()
+    count = 0
+
+    with tempfile.NamedTemporaryFile(suffix=".download") as dl_tmp:
+        _download(url, dl_tmp.name)
+
+        open_fn = gzip.open if use_gzip_input else open
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl.gz", delete=False) as out_tmp:
+            out_tmp_path = out_tmp.name
+
+        try:
+            with (
+                open_fn(dl_tmp.name, "rb") as infile,
+                gzip.open(out_tmp_path, "wb") as outfile,
+            ):
+                for obj in parser_class(infile, validate_with_schema=False):
+                    outfile.write(orjson.dumps(obj))
+                    outfile.write(b"\n")
+                    count += 1
+                    if count % 100_000 == 0:
+                        log.info(f"{entity}: parsed {count:,} records")
+
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(out_tmp_path, "rb") as src, output_path.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+        finally:
+            UPath(out_tmp_path).unlink(missing_ok=True)
+
+    duration = time.time() - start
+    log.info(
+        f"{entity}: wrote {count:,} records to {output_path} "
+        f"in {duration:.1f}s ({count / max(duration, 1e-3):.0f} rec/s)"
+    )
+    return {
+        "row_count": count,
+        "output_path": str(output_path),
+        "duration_seconds": duration,
+        "source_url": url,
+    }
+
+
+@task(retries=2, retry_delay_seconds=30)
+def extract_biosample(force: bool = False) -> dict:
+    log = get_run_logger()
+    sem = SemaphoreStore("biosample")
+    key = date.today().isoformat()
+    if not force and sem.exists(key):
+        log.info(f"biosample/{key}: semaphore exists, skipping")
+        return {"key": key, "skipped": True}
+
+    output_dir = get_upath("biosample", "raw")
+    meta = _extract_entity(
+        url=BIOSAMPLE_URL,
+        entity="biosample",
+        parser_class=BioSampleParser,
+        use_gzip_input=True,
+        output_dir=output_dir,
+    )
+    sem.mark_done(key, metadata=meta)
+    return {"key": key, "skipped": False, **meta}
+
+
+@task(retries=2, retry_delay_seconds=30)
+def extract_bioproject(force: bool = False) -> dict:
+    log = get_run_logger()
+    sem = SemaphoreStore("bioproject")
+    key = date.today().isoformat()
+    if not force and sem.exists(key):
+        log.info(f"bioproject/{key}: semaphore exists, skipping")
+        return {"key": key, "skipped": True}
+
+    output_dir = get_upath("bioproject", "raw")
+    meta = _extract_entity(
+        url=BIOPROJECT_URL,
+        entity="bioproject",
+        parser_class=BioProjectParser,
+        use_gzip_input=False,
+        output_dir=output_dir,
+    )
+    sem.mark_done(key, metadata=meta)
+    return {"key": key, "skipped": False, **meta}
+
+
+@task(retries=1, retry_delay_seconds=60)
+def bioproject_to_parquet() -> dict:
+    """Convert BioProject JSONL → parquet via DuckDB. Always runs (cheap)."""
+    log = get_run_logger()
+    input_path = get_duckdb_path("bioproject", "raw", "data.jsonl.gz")
+    output_path = get_duckdb_path("bioproject", "parquet", "bioprojects.parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(title) as title,
+                trim(description) as description,
+                trim(name) as name,
+                trim(accession) as accession,
+                publications,
+                locus_tags,
+                release_date,
+                data_types,
+                external_links
+            FROM read_ndjson_auto(
+                '{input_path}',
+                maximum_object_size = 1000000000
+            )
+        ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION ZSTD);
+    """
+    with get_duckdb_connection() as con:
+        log.info(f"Converting {input_path} to {output_path}")
+        con.execute(sql)
+        row_count = con.execute(
+            f"SELECT count(*) FROM read_parquet('{output_path}')"
+        ).fetchone()[0]
+    log.info(f"Wrote {row_count:,} rows to {output_path}")
+    return {"row_count": row_count, "output_path": output_path}
+
+
+@flow(name="biosample-extract")
+def biosample_extract_flow(force: bool = False) -> None:
+    extract_biosample(force=force)
+
+
+@flow(name="bioproject-extract")
+def bioproject_extract_flow(force: bool = False) -> None:
+    extract_bioproject(force=force)
+    bioproject_to_parquet()
+
+
+if __name__ == "__main__":
+    biosample_extract_flow()
+    bioproject_extract_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/consolidate.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/consolidate.py
@@ -1,0 +1,404 @@
+"""Consolidation flow: raw partitions → per-entity parquet.
+
+Each entity is a separate task running a DuckDB COPY. Tasks here are
+not partitioned — they aggregate across all raw partitions for the
+entity. The flow takes no semaphores; the cost is in re-aggregation
+(seconds-to-minutes) not in the upstream raw extracts.
+"""
+
+import httpx
+from omicidx.prefect.config import get_duckdb_connection, get_duckdb_path
+
+from prefect import flow, get_run_logger, task
+
+_SRA_ACCESSIONS_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/sra/reports/Metadata/SRA_Accessions.tab"
+)
+
+
+def _run_copy(sql: str, output_path: str) -> int:
+    log = get_run_logger()
+    with get_duckdb_connection() as con:
+        log.info(f"Consolidating to {output_path}")
+        con.execute(sql)
+        row_count = con.execute(
+            f"SELECT count(*) FROM read_parquet('{output_path}')"
+        ).fetchone()[0]
+    log.info(f"Wrote {row_count:,} rows to {output_path}")
+    return row_count
+
+
+# -- GEO -----------------------------------------------------------------------
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_platforms_parquet() -> int:
+    output = get_duckdb_path("geo", "parquet", "geo_platforms.parquet")
+    input_path = get_duckdb_path("geo", "raw", "gpl", "**", "*.ndjson.gz")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(title) as title, trim(status) as status,
+                submission_date, last_update_date,
+                trim(accession) as accession, contact,
+                trim(organism) as organism, sample_id, series_id,
+                trim(technology) as technology,
+                trim(description) as description,
+                trim(distribution) as distribution,
+                manufacturer, data_row_count, contributor, relation,
+                trim(manufacture_protocol) as manufacture_protocol
+            FROM read_ndjson_auto('{input_path}')
+            QUALIFY row_number() OVER (PARTITION BY accession ORDER BY last_update_date DESC NULLS LAST) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_series_parquet() -> int:
+    output = get_duckdb_path("geo", "parquet", "geo_series.parquet")
+    input_path = get_duckdb_path("geo", "raw", "gse", "**", "*.ndjson.gz")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(title) as title, trim(status) as status,
+                submission_date, last_update_date,
+                trim(accession) as accession, subseries, bioprojects,
+                sra_studies, contact, type, trim(summary) as summary,
+                relation, pubmed_id, sample_id, sample_taxid,
+                sample_organism, platform_id, platform_taxid,
+                platform_organism, supplemental_files,
+                trim(overall_design) as overall_design, contributor
+            FROM read_ndjson_auto('{input_path}')
+            QUALIFY row_number() OVER (PARTITION BY accession ORDER BY last_update_date DESC NULLS LAST) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_samples_parquet() -> int:
+    output = get_duckdb_path("geo", "parquet", "geo_samples.parquet")
+    input_path = get_duckdb_path("geo", "raw", "gsm", "**", "*.ndjson.gz")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(title) as title, trim(status) as status,
+                submission_date, last_update_date,
+                trim(type) as type, trim(anchor) as anchor,
+                contact, trim(description) as description,
+                trim(accession) as accession, biosample, tag_count,
+                tag_length, trim(platform_id) as platform_id,
+                trim(hyb_protocol) as hyb_protocol, channel_count,
+                trim(scan_protocol) as scan_protocol, data_row_count,
+                library_source, sra_experiment,
+                trim(data_processing) as data_processing,
+                supplemental_files, channels, contributor
+            FROM read_ndjson_auto('{input_path}')
+            QUALIFY row_number() OVER (PARTITION BY accession ORDER BY last_update_date DESC NULLS LAST) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_rnaseq_counts_parquet() -> int:
+    output = get_duckdb_path(
+        "geo", "parquet", "geo_series_with_rnaseq_counts.parquet"
+    )
+    input_path = get_duckdb_path("geo", "raw", "gse_with_rna_seq_counts.parquet")
+    sql = f"""
+        COPY (
+            SELECT accession
+            FROM read_parquet('{input_path}')
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+# -- SRA -----------------------------------------------------------------------
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_studies_parquet() -> int:
+    output = get_duckdb_path("sra", "parquet", "sra_studies.parquet")
+    input_path = get_duckdb_path("sra", "raw", "study", "**", "*parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(accession) as accession,
+                trim(study_accession) as study_accession,
+                trim(alias) as alias, trim(title) as title,
+                trim(description) as description,
+                trim(abstract) as abstract,
+                trim(study_type) as study_type,
+                trim(center_name) as center_name,
+                trim(broker_name) as broker_name,
+                trim("BioProject") as bioproject,
+                trim("GEO") as geo,
+                identifiers, attributes, xrefs, pubmed_ids
+            FROM read_parquet('{input_path}', hive_partitioning=true)
+            QUALIFY row_number() OVER (
+                PARTITION BY accession ORDER BY date DESC, stage DESC
+            ) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_samples_parquet() -> int:
+    output = get_duckdb_path("sra", "parquet", "sra_samples.parquet")
+    input_path = get_duckdb_path("sra", "raw", "sample", "**", "*parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(accession) as accession,
+                trim(alias) as alias, trim(title) as title,
+                trim(organism) as organism,
+                trim(description) as description,
+                taxon_id,
+                trim("BioSample") as biosample,
+                identifiers, attributes, xrefs
+            FROM read_parquet('{input_path}', hive_partitioning=true)
+            QUALIFY row_number() OVER (
+                PARTITION BY accession ORDER BY date DESC, stage DESC
+            ) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_experiments_parquet() -> int:
+    output = get_duckdb_path("sra", "parquet", "sra_experiments.parquet")
+    input_path = get_duckdb_path("sra", "raw", "experiment", "**", "*parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(accession) as accession,
+                trim(experiment_accession) as experiment_accession,
+                trim(alias) as alias, trim(title) as title,
+                trim(design) as design,
+                trim(center_name) as center_name,
+                trim(study_accession) as study_accession,
+                trim(sample_accession) as sample_accession,
+                trim(platform) as platform,
+                trim(instrument_model) as instrument_model,
+                trim(library_name) as library_name,
+                trim(library_construction_protocol) as library_construction_protocol,
+                trim(library_layout) as library_layout,
+                trim(library_layout_length) as library_layout_length,
+                trim(library_layout_sdev) as library_layout_sdev,
+                trim(library_strategy) as library_strategy,
+                trim(library_source) as library_source,
+                trim(library_selection) as library_selection,
+                spot_length, nreads,
+                identifiers, attributes, xrefs, reads
+            FROM read_parquet('{input_path}', hive_partitioning=true)
+            QUALIFY row_number() OVER (
+                PARTITION BY accession ORDER BY date DESC, stage DESC
+            ) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_runs_parquet() -> int:
+    output = get_duckdb_path("sra", "parquet", "sra_runs.parquet")
+    input_path = get_duckdb_path("sra", "raw", "run", "**", "*parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(accession) as accession,
+                trim(alias) as alias,
+                trim(experiment_accession) as experiment_accession,
+                trim(title) as title,
+                identifiers, attributes, qualities
+            FROM read_parquet('{input_path}', hive_partitioning=true)
+            QUALIFY row_number() OVER (
+                PARTITION BY accession ORDER BY date DESC, stage DESC
+            ) = 1
+            ORDER BY accession
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_accessions_parquet() -> int:
+    """Ingest SRA_Accessions.tab → parquet. Checked for ETag freshness upstream."""
+    output = get_duckdb_path("sra", "parquet", "sra_accessions.parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim("Accession") as accession,
+                trim("Submission") as submission,
+                trim("Status") as status,
+                "Updated" as updated, "Published" as published,
+                "Received" as received,
+                trim("Type") as type, trim("Center") as center,
+                trim("Visibility") as visibility,
+                trim("Alias") as alias,
+                trim("Experiment") as experiment,
+                trim("Sample") as sample, trim("Study") as study,
+                "Loaded" as loaded, "Spots" as spots, "Bases" as bases,
+                trim("Md5sum") as md5sum,
+                trim("BioSample") as biosample,
+                trim("BioProject") as bioproject,
+                trim("ReplacedBy") as replacedby
+            FROM read_csv_auto(
+                '{_SRA_ACCESSIONS_URL}',
+                nullstr = '-'
+            )
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+def _fetch_etag(url: str) -> str | None:
+    try:
+        response = httpx.head(url, timeout=10, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.RequestError:
+        return None
+    etag = response.headers.get("ETag")
+    if etag:
+        etag = etag.strip('"')
+    return etag
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_accessions_if_changed(force: bool = False) -> dict:
+    """Run sra_accessions_parquet only if the URL's ETag changed.
+
+    The semaphore for namespace `sra_accessions_etag` stores the most
+    recently seen ETag (one key: 'latest'). If the upstream ETag differs
+    we re-ingest and update the semaphore.
+    """
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    log = get_run_logger()
+    sem = SemaphoreStore("sra_accessions_etag")
+    etag = _fetch_etag(_SRA_ACCESSIONS_URL)
+    if not etag:
+        log.warning("No ETag returned for SRA_Accessions.tab; running ingest anyway")
+    else:
+        last = sem.read("latest")
+        last_etag = (last or {}).get("metadata", {}).get("etag")
+        if not force and etag == last_etag:
+            log.info(f"SRA_Accessions ETag unchanged ({etag}); skipping ingest")
+            return {"skipped": True, "etag": etag}
+
+    rows = sra_accessions_parquet()
+    sem.mark_done(
+        "latest",
+        metadata={"etag": etag, "row_count": rows, "url": _SRA_ACCESSIONS_URL},
+    )
+    return {"skipped": False, "etag": etag, "row_count": rows}
+
+
+# -- BioSample -----------------------------------------------------------------
+
+
+@task(retries=1, retry_delay_seconds=60)
+def biosample_parquet() -> int:
+    output = get_duckdb_path("biosample", "parquet", "biosamples.parquet")
+    input_path = get_duckdb_path("biosample", "raw", "data.jsonl.gz")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(submission_date) as submission_date,
+                trim(last_update) as last_update,
+                trim(publication_date) as publication_date,
+                trim(access) as access,
+                trim(id) as id,
+                trim(accession) as accession,
+                id_recs, ids,
+                trim(sra_sample) as sra_sample,
+                trim(dbgap) as dbgap,
+                trim(gsm) as gsm,
+                trim(title) as title,
+                trim(description) as description,
+                trim(taxonomy_name) as taxonomy_name,
+                taxon_id, attribute_recs, attributes,
+                trim(model) as model
+            FROM read_ndjson_auto(
+                '{input_path}',
+                maximum_object_size = 1000000000
+            )
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+# -- PubMed --------------------------------------------------------------------
+
+
+@task(retries=1, retry_delay_seconds=60)
+def pubmed_parquet() -> int:
+    output = get_duckdb_path("pubmed", "parquet", "pubmed_articles.parquet")
+    input_path = get_duckdb_path("pubmed", "raw", "*.parquet")
+    sql = f"""
+        COPY (
+            SELECT
+                trim(title) as title, trim(issue) as issue,
+                trim(pages) as pages, trim(abstract) as abstract,
+                trim(journal) as journal, authors,
+                trim(pubdate) as pubdate, trim(pmid) as pmid,
+                trim(mesh_terms) as mesh_terms,
+                trim(publication_types) as publication_types,
+                trim(chemical_list) as chemical_list,
+                trim(keywords) as keywords, trim(doi) as doi,
+                "references",
+                trim(languages) as languages,
+                trim(vernacular_title) as vernacular_title,
+                trim(date_completed) as date_completed,
+                trim(date_revised) as date_revised,
+                trim(pmc) as pmc, trim(other_id) as other_id,
+                trim(medline_ta) as medline_ta,
+                trim(nlm_unique_id) as nlm_unique_id,
+                trim(issn_linking) as issn_linking,
+                trim(country) as country, grant_ids
+            FROM read_parquet('{input_path}')
+            WHERE delete IS NOT TRUE
+            QUALIFY row_number() OVER (
+                PARTITION BY pmid
+                ORDER BY TRY_CAST(date_revised AS DATE) DESC NULLS LAST,
+                         TRY_CAST(date_completed AS DATE) DESC NULLS LAST
+            ) = 1
+            ORDER BY pmid
+        ) TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    return _run_copy(sql, output)
+
+
+# -- Top-level consolidation flow ---------------------------------------------
+
+
+@flow(name="consolidate")
+def consolidate_flow() -> None:
+    """Run every per-entity consolidation task. Order is unconstrained."""
+    geo_platforms_parquet()
+    geo_series_parquet()
+    geo_samples_parquet()
+    geo_rnaseq_counts_parquet()
+    sra_studies_parquet()
+    sra_samples_parquet()
+    sra_experiments_parquet()
+    sra_runs_parquet()
+    sra_accessions_if_changed()
+    biosample_parquet()
+    pubmed_parquet()
+
+
+if __name__ == "__main__":
+    consolidate_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
@@ -1,0 +1,221 @@
+"""EBI Biosample extract flow.
+
+Partitions are calendar days (YYYY-MM-DD), starting at 2021-01-01. Each
+day gets a semaphore at `_semaphores/ebi_biosample/{YYYY-MM-DD}.json`,
+including empty days (legitimately many days have zero updates). The
+flow defaults to enumerating from the start date to today, processing
+only missing-semaphore days. The current day is always re-run.
+"""
+
+import asyncio
+import gzip
+import shutil
+import tempfile
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import orjson
+import tenacity
+from omicidx.prefect.config import get_duckdb_connection, get_duckdb_path, get_upath
+from omicidx.prefect.semaphore import SemaphoreStore
+
+from prefect import flow, get_run_logger, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+EBI_BIOSAMPLES_BASE_URL = "https://www.ebi.ac.uk/biosamples/samples"
+EBI_PAGE_SIZE = 200
+EBI_REQUEST_TIMEOUT = 40.0
+
+
+def _partition_filename(partition_date: date) -> str:
+    return f"biosamples-{partition_date.isoformat()}.ndjson.gz"
+
+
+class _SampleFetcher:
+    def __init__(self, *, partition_date: date, local_path: Path) -> None:
+        self.partition_date = partition_date
+        self.local_path = local_path
+        self.cursor = "*"
+        self.next_url: str | None = None
+
+    def _filter(self) -> str:
+        d = self.partition_date.isoformat()
+        return f"dt:update:from={d}until={d}"
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(10),
+        wait=tenacity.wait_random_exponential(multiplier=1, max=40),
+        retry=tenacity.retry_if_exception_type(httpx.HTTPError),
+    )
+    async def _request(self, client: httpx.AsyncClient) -> dict:
+        if self.next_url is not None:
+            response = await client.get(self.next_url, timeout=EBI_REQUEST_TIMEOUT)
+        else:
+            params = {
+                "cursor": self.cursor,
+                "size": EBI_PAGE_SIZE,
+                "filter": self._filter(),
+            }
+            response = await client.get(
+                EBI_BIOSAMPLES_BASE_URL,
+                params=params,
+                timeout=EBI_REQUEST_TIMEOUT,
+            )
+        response.raise_for_status()
+        return response.json()
+
+    async def _iter_samples(self, client: httpx.AsyncClient):
+        while True:
+            payload = await self._request(client)
+            samples = payload.get("_embedded", {}).get("samples")
+            if not samples:
+                return
+            for sample in samples:
+                flattened = []
+                for k, values in sample.get("characteristics", {}).items():
+                    for v in values:
+                        v["characteristic"] = k
+                        flattened.append(v)
+                sample["characteristics"] = flattened
+                yield sample
+
+            next_link = payload.get("_links", {}).get("next")
+            if not next_link:
+                return
+            self.next_url = next_link["href"]
+
+    async def run(self) -> int:
+        count = 0
+        async with httpx.AsyncClient() as client:
+            with gzip.open(self.local_path, "wb") as fh:
+                async for sample in self._iter_samples(client):
+                    fh.write(orjson.dumps(sample))
+                    fh.write(b"\n")
+                    count += 1
+        return count
+
+
+@task(
+    retries=2,
+    retry_delay_seconds=30,
+    task_run_name="ebi-biosample-extract-{key}",
+)
+def extract_ebi_biosample(key: str, force: bool = False) -> dict:
+    log = get_run_logger()
+    sem = SemaphoreStore("ebi_biosample")
+    if not force and sem.exists(key):
+        log.info(f"ebi_biosample/{key}: semaphore exists, skipping")
+        return {"key": key, "skipped": True}
+
+    partition_date = datetime.strptime(key, "%Y-%m-%d").date()
+    output_dir = get_upath("ebi_biosample", "raw")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_path = output_dir / _partition_filename(partition_date)
+
+    log.info(f"Fetching EBI biosamples for {partition_date.isoformat()}")
+
+    with tempfile.NamedTemporaryFile(suffix=".ndjson.gz", delete=False) as tmp:
+        local_path = Path(tmp.name)
+
+    try:
+        fetcher = _SampleFetcher(partition_date=partition_date, local_path=local_path)
+        record_count = asyncio.run(fetcher.run())
+
+        if record_count == 0:
+            log.info(
+                f"No samples updated on {partition_date.isoformat()} "
+                "(this is expected for many days)"
+            )
+            sem.mark_done(
+                key,
+                metadata={"row_count": 0, "note": "no samples updated"},
+            )
+            return {"key": key, "skipped": False, "row_count": 0}
+
+        with open(local_path, "rb") as src, final_path.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+        size_bytes = local_path.stat().st_size
+        log.info(
+            f"Wrote {record_count:,} records to {final_path} "
+            f"({size_bytes / (1024 * 1024):.2f} MB)"
+        )
+        sem.mark_done(
+            key,
+            metadata={
+                "row_count": record_count,
+                "output_path": str(final_path),
+                "file_size_bytes": size_bytes,
+            },
+        )
+        return {"key": key, "skipped": False, "row_count": record_count}
+    finally:
+        local_path.unlink(missing_ok=True)
+
+
+def _enumerate_days(start: str = "2021-01-01", end: str | None = None) -> list[str]:
+    start_d = datetime.strptime(start, "%Y-%m-%d").date()
+    end_d = (
+        datetime.strptime(end, "%Y-%m-%d").date() if end else date.today()
+    )
+    keys: list[str] = []
+    cur = start_d
+    while cur <= end_d:
+        keys.append(cur.isoformat())
+        cur = cur + timedelta(days=1)
+    return keys
+
+
+@task(retries=1, retry_delay_seconds=60)
+def consolidate_ebi_biosample_parquet() -> dict:
+    """Consolidate per-day NDJSON into a single parquet via DuckDB."""
+    log = get_run_logger()
+    input_glob = get_duckdb_path("ebi_biosample", "raw", "biosamples-*.ndjson.gz")
+    output_path = get_duckdb_path("ebi_biosample", "parquet", "ebi_biosamples.parquet")
+    sql = f"""
+        COPY (
+            SELECT *
+            FROM read_ndjson_auto(
+                '{input_glob}',
+                maximum_object_size = 1000000000,
+                ignore_errors = false
+            )
+        ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """
+    with get_duckdb_connection() as con:
+        log.info(f"Consolidating {input_glob} → {output_path}")
+        con.execute(sql)
+        row_count = con.execute(
+            f"SELECT count(*) FROM read_parquet('{output_path}')"
+        ).fetchone()[0]
+    log.info(f"Wrote {row_count:,} rows to {output_path}")
+    return {"row_count": row_count, "output_path": output_path}
+
+
+@flow(
+    name="ebi-biosample-extract",
+    task_runner=ThreadPoolTaskRunner(max_workers=4),
+)
+def ebi_biosample_extract_flow(
+    start_day: str = "2021-01-01",
+    end_day: str | None = None,
+    rerun_current_day: bool = True,
+    force: bool = False,
+    consolidate: bool = True,
+) -> None:
+    days = _enumerate_days(start=start_day, end=end_day)
+    current_key = date.today().isoformat()
+    futures = []
+    for key in days:
+        force_this = force or (rerun_current_day and key == current_key)
+        futures.append(extract_ebi_biosample.submit(key=key, force=force_this))
+    for fut in futures:
+        fut.result()
+
+    if consolidate:
+        consolidate_ebi_biosample_parquet()
+
+
+if __name__ == "__main__":
+    ebi_biosample_extract_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -1,0 +1,323 @@
+"""GEO extract flow.
+
+Partitions are calendar months (YYYY-MM). Each month gets a semaphore
+under `_semaphores/geo/{YYYY-MM}.json`. By default the flow processes
+the current month every run (`rerun_current_month=True`) and skips any
+historical month that already has a semaphore.
+
+A second non-partitioned step (`geo_rna_seq_counts_flow`) refreshes the
+list of GSEs with RNA-seq counts; it has no partitioning.
+"""
+
+import asyncio
+import gzip
+import re
+import shutil
+import tempfile
+import time
+from datetime import date, datetime, timedelta
+
+import httpx
+import orjson
+import polars as pl
+import tenacity
+from dateutil.relativedelta import relativedelta
+from omicidx.parsers.geo import parser as gp
+from omicidx.prefect.config import get_upath
+from omicidx.prefect.semaphore import SemaphoreStore
+from upath import UPath
+
+from prefect import flow, get_run_logger, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _month_key(partition_date: date) -> str:
+    return partition_date.strftime("%Y-%m")
+
+
+def _month_range(partition_date: date) -> tuple[date, date]:
+    start = partition_date.replace(day=1)
+    end = (start + relativedelta(months=1)) - timedelta(days=1)
+    return start, end
+
+
+def _entrezid_to_geo(entrezid: str) -> str:
+    if entrezid.startswith("2"):
+        return re.sub("^20*", "GSE", entrezid)
+    if entrezid.startswith("1"):
+        return re.sub("^10*", "GPL", entrezid)
+    if entrezid.startswith("3"):
+        return re.sub("^30*", "GSM", entrezid)
+    raise ValueError(f"Expected entrezid to start with 1, 2, or 3: {entrezid}")
+
+
+@tenacity.retry(
+    wait=tenacity.wait_exponential_jitter(2, 60),
+    stop=tenacity.stop_after_attempt(8),
+    retry=tenacity.retry_if_exception(
+        lambda e: (
+            (
+                isinstance(e, httpx.HTTPStatusError)
+                and (
+                    e.response.status_code == 429 or 500 <= e.response.status_code < 600
+                )
+            )
+            or isinstance(
+                e,
+                httpx.RemoteProtocolError | httpx.ConnectError | httpx.TimeoutException,
+            )
+        )
+    ),
+)
+async def _fetch_accessions(start_date: date, end_date: date) -> list[str]:
+    accessions: list[str] = []
+    offset = 0
+    retmax = 5000
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        while True:
+            response = await client.get(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+                params={
+                    "db": "gds",
+                    "term": (
+                        f"(GSM[etyp] OR GSE[etyp] OR GPL[etyp]) AND "
+                        f'("{start_date.strftime("%Y/%m/%d")}"[Update Date] : '
+                        f'"{end_date.strftime("%Y/%m/%d")}"[Update Date])'
+                    ),
+                    "retmode": "json",
+                    "retmax": retmax,
+                    "retstart": offset,
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+            ids = result["esearchresult"]["idlist"]
+            for eid in ids:
+                accessions.append(_entrezid_to_geo(eid))
+            if len(ids) < retmax:
+                break
+            offset += retmax
+            await asyncio.sleep(0.4)
+
+    return accessions
+
+
+@tenacity.retry(
+    wait=tenacity.wait_exponential_jitter(2, 30),
+    stop=tenacity.stop_after_attempt(5),
+)
+async def _fetch_soft(accession: str, client: httpx.AsyncClient) -> str:
+    params = {
+        "acc": accession,
+        "targ": "self",
+        "form": "text",
+        "view": "quick" if accession.startswith("GSM") else "brief",
+    }
+    response = await client.get(
+        "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi", params=params
+    )
+    response.raise_for_status()
+    return response.text
+
+
+async def _fetch_and_parse(
+    accessions: list[str], concurrency: int = 30
+) -> dict[str, list[dict]]:
+    results: dict[str, list[dict]] = {"GSE": [], "GSM": [], "GPL": []}
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _one(acc: str, client: httpx.AsyncClient) -> None:
+        async with semaphore:
+            text = await _fetch_soft(acc, client)
+            lines = [x.strip() for x in text.split("\n")]
+            entity = gp._parse_single_entity_soft(lines)
+            if entity is not None:
+                prefix = entity.accession[:3]
+                if prefix in results:
+                    results[prefix].append(entity.model_dump())
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        await asyncio.gather(
+            *(_one(acc, client) for acc in accessions), return_exceptions=True
+        )
+
+    return results
+
+
+def _write_ndjson_gz(records: list[dict], path: UPath) -> int:
+    with tempfile.NamedTemporaryFile(suffix=".ndjson.gz", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        with gzip.open(tmp_path, "wb") as f:
+            for rec in records:
+                f.write(orjson.dumps(rec))
+                f.write(b"\n")
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp_path, "rb") as src, path.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+    finally:
+        UPath(tmp_path).unlink(missing_ok=True)
+
+    return len(records)
+
+
+# ---------------------------------------------------------------------------
+# Per-month extract task
+# ---------------------------------------------------------------------------
+
+
+@task(retries=2, retry_delay_seconds=60, task_run_name="geo-extract-{key}")
+def extract_month(key: str, force: bool = False) -> dict:
+    """Extract one calendar-month partition of GEO metadata."""
+    log = get_run_logger()
+    sem = SemaphoreStore("geo")
+
+    if not force and sem.exists(key):
+        log.info(f"geo/{key}: semaphore exists, skipping")
+        return {"key": key, "skipped": True}
+
+    partition_date = datetime.strptime(key, "%Y-%m").date()
+    start_date, end_date = _month_range(partition_date)
+    output_base = get_upath("geo", "raw")
+
+    log.info(f"Processing GEO {start_date} to {end_date}")
+
+    accessions = asyncio.run(_fetch_accessions(start_date, end_date))
+    log.info(f"Found {len(accessions)} accessions for {key}")
+
+    counts = {"GSE": 0, "GSM": 0, "GPL": 0}
+
+    if accessions:
+        parsed = asyncio.run(_fetch_and_parse(accessions))
+    else:
+        parsed = {"GSE": [], "GSM": [], "GPL": []}
+
+    for prefix, entity in [("GSE", "gse"), ("GSM", "gsm"), ("GPL", "gpl")]:
+        path = (
+            output_base
+            / entity
+            / f"year={start_date.strftime('%Y')}"
+            / f"month={start_date.strftime('%m')}"
+            / "data_0.ndjson.gz"
+        )
+        n = _write_ndjson_gz(parsed[prefix], path)
+        counts[prefix] = n
+        log.info(f"Wrote {n} {prefix} records to {path}")
+
+    sem.mark_done(
+        key,
+        metadata={
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            **counts,
+        },
+    )
+    return {"key": key, "skipped": False, **counts}
+
+
+# ---------------------------------------------------------------------------
+# RNA-seq counts (non-partitioned)
+# ---------------------------------------------------------------------------
+
+
+@task(retries=2, retry_delay_seconds=30)
+def fetch_rna_seq_counts() -> dict:
+    log = get_run_logger()
+    offset = 0
+    retmax = 5000
+    accessions: list[dict] = []
+
+    with httpx.Client(timeout=60) as client:
+        while True:
+            response = client.get(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+                params={
+                    "db": "gds",
+                    "term": '"rnaseq+counts"[filter]',
+                    "retmode": "json",
+                    "retmax": retmax,
+                    "retstart": offset,
+                },
+            )
+            response.raise_for_status()
+            ids = response.json()["esearchresult"]["idlist"]
+            for eid in ids:
+                accessions.append({"accession": _entrezid_to_geo(eid)})
+            if len(ids) < retmax:
+                break
+            offset += retmax
+            time.sleep(0.5)
+
+    df = pl.DataFrame(accessions)
+    outpath = get_upath("geo", "raw", "gse_with_rna_seq_counts.parquet")
+    outpath.parent.mkdir(parents=True, exist_ok=True)
+
+    with outpath.open("wb") as f:
+        df.write_parquet(f, use_pyarrow=True, compression="zstd")
+
+    log.info(f"Wrote {len(accessions)} GSEs with RNA-seq counts to {outpath}")
+    return {"row_count": len(accessions), "output_path": str(outpath)}
+
+
+# ---------------------------------------------------------------------------
+# Flows
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_months(start: str = "2005-01", end: str | None = None) -> list[str]:
+    start_d = datetime.strptime(start, "%Y-%m").date().replace(day=1)
+    end_d = (
+        datetime.strptime(end, "%Y-%m").date().replace(day=1)
+        if end
+        else date.today().replace(day=1)
+    )
+    keys: list[str] = []
+    cur = start_d
+    while cur <= end_d:
+        keys.append(_month_key(cur))
+        cur = cur + relativedelta(months=1)
+    return keys
+
+
+@flow(
+    name="geo-extract",
+    task_runner=ThreadPoolTaskRunner(max_workers=2),
+)
+def geo_extract_flow(
+    start_month: str = "2005-01",
+    end_month: str | None = None,
+    rerun_current_month: bool = True,
+    force: bool = False,
+) -> None:
+    """Extract GEO metadata, one monthly partition at a time.
+
+    By default iterates from ``start_month`` to the current month, skipping
+    any month whose semaphore exists. Set ``force=True`` to re-extract
+    everything in the range. Set ``rerun_current_month=False`` to also
+    skip the current month if its semaphore exists.
+    """
+    months = _enumerate_months(start=start_month, end=end_month)
+    current_key = _month_key(date.today())
+    futures = []
+    for key in months:
+        force_this = force or (rerun_current_month and key == current_key)
+        futures.append(extract_month.submit(key=key, force=force_this))
+    for fut in futures:
+        fut.result()
+
+
+@flow(name="geo-rna-seq-counts")
+def geo_rna_seq_counts_flow() -> None:
+    """Refresh the (small) GSE-with-RNA-seq-counts file. Not partitioned."""
+    fetch_rna_seq_counts()
+
+
+if __name__ == "__main__":
+    geo_extract_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -1,0 +1,46 @@
+"""Top-level pipeline flows.
+
+`daily_pipeline_flow` mirrors the Dagster `daily_extract_schedule` plus
+the downstream cascade — it runs the raw extracts, then consolidation,
+then the postgres loads, then the duckdb build. Each step is a
+subflow, so failure of one stage halts the rest with full visibility.
+"""
+
+from omicidx.prefect.flows.biosample import (
+    bioproject_extract_flow,
+    biosample_extract_flow,
+)
+from omicidx.prefect.flows.consolidate import consolidate_flow
+from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
+from omicidx.prefect.flows.geo import geo_extract_flow, geo_rna_seq_counts_flow
+from omicidx.prefect.flows.postgres import postgres_load_flow
+from omicidx.prefect.flows.pubmed import pubmed_extract_flow
+from omicidx.prefect.flows.sql import omicidx_duckdb_flow
+from omicidx.prefect.flows.sra import sra_extract_flow
+
+from prefect import flow
+
+
+@flow(name="raw-extract")
+def raw_extract_flow(force: bool = False) -> None:
+    """Run every raw extractor. Mirrors `daily_extract_schedule`."""
+    biosample_extract_flow(force=force)
+    bioproject_extract_flow(force=force)
+    sra_extract_flow(force=force)
+    geo_extract_flow(force=force)
+    geo_rna_seq_counts_flow()
+    ebi_biosample_extract_flow(force=force)
+    pubmed_extract_flow(force=force)
+
+
+@flow(name="daily-pipeline")
+def daily_pipeline_flow(force: bool = False) -> None:
+    """Daily end-to-end pipeline: extract → consolidate → load → build."""
+    raw_extract_flow(force=force)
+    consolidate_flow()
+    postgres_load_flow()
+    omicidx_duckdb_flow()
+
+
+if __name__ == "__main__":
+    daily_pipeline_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
@@ -1,0 +1,658 @@
+"""Postgres-load flow.
+
+One task per entity. Each task loads the consolidated parquet into a
+Postgres backing table (A/B-slot pattern) and atomically swaps a view
+to point at the new one. The API reads through the view, so reads
+never block during reload.
+"""
+
+import asyncio
+import re
+
+from omicidx.prefect.config import (
+    attach_postgres,
+    execute_postgres_sql,
+    get_duckdb_connection,
+    get_duckdb_path,
+    postgres_async_uri,
+)
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from prefect import flow, get_run_logger, task
+
+
+def _validate_sql_identifier(name: str) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        raise ValueError(f"Invalid SQL identifier: {name!r}")
+    return name
+
+
+def _escape_sql_single_quotes(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _escape_format_braces(value: str) -> str:
+    return value.replace("{", "{{").replace("}", "}}")
+
+
+def _get_live_backing_table(view_name: str) -> str | None:
+    """Return the live `{view}_a|{view}_b` backing table, or None."""
+    view_name = _validate_sql_identifier(view_name)
+
+    async def _check() -> str | None:
+        engine = create_async_engine(postgres_async_uri())
+        async with engine.begin() as conn:
+            view_exists_result = await conn.execute(
+                text("""
+                    SELECT 1
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                """),
+                {"view_name": view_name},
+            )
+            view_exists = view_exists_result.first() is not None
+            referenced_result = await conn.execute(
+                text("""
+                    SELECT DISTINCT cls.relname
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    JOIN pg_rewrite rw ON rw.ev_class = view_cls.oid
+                    JOIN pg_depend dep ON dep.objid = rw.oid
+                    JOIN pg_class cls ON cls.oid = dep.refobjid
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                      AND cls.relkind IN ('r', 'p')
+                """),
+                {"view_name": view_name},
+            )
+            referenced_tables = [row[0] for row in referenced_result.fetchall()]
+            slot_a = f"{view_name}_a"
+            slot_b = f"{view_name}_b"
+            result = await conn.execute(
+                text("""
+                    SELECT DISTINCT cls.relname
+                    FROM pg_class view_cls
+                    JOIN pg_namespace view_ns ON view_ns.oid = view_cls.relnamespace
+                    JOIN pg_rewrite rw ON rw.ev_class = view_cls.oid
+                    JOIN pg_depend dep ON dep.objid = rw.oid
+                    JOIN pg_class cls ON cls.oid = dep.refobjid
+                    WHERE view_cls.relkind = 'v'
+                      AND view_ns.nspname = 'public'
+                      AND view_cls.relname = :view_name
+                      AND cls.relkind IN ('r', 'p')
+                      AND (cls.relname = :slot_a OR cls.relname = :slot_b)
+                """),
+                {"view_name": view_name, "slot_a": slot_a, "slot_b": slot_b},
+            )
+            rows = result.fetchall()
+        await engine.dispose()
+        if not rows:
+            if view_exists:
+                referenced = ", ".join(referenced_tables) or "none"
+                raise ValueError(
+                    f"View {view_name!r} does not reference expected A/B tables "
+                    f"({slot_a}, {slot_b}); found: {referenced}. "
+                    "Check for manual schema/view changes."
+                )
+            return None
+        if len(rows) > 1:
+            table_names = ", ".join(row[0] for row in rows)
+            raise ValueError(
+                f"View {view_name!r} references multiple backing tables: {table_names}. "
+                "Check for manual schema/view modifications or orphaned A/B tables."
+            )
+        return rows[0][0]
+
+    return asyncio.run(_check())
+
+
+def _load(
+    *,
+    table: str,
+    ddl: str,
+    parquet_parts: tuple[str, ...],
+    insert_sql_template: str,
+    indexes: str | None = None,
+) -> int:
+    """Load parquet into Postgres with zero-downtime view swap."""
+    log = get_run_logger()
+    table = _validate_sql_identifier(table)
+    parquet_path = get_duckdb_path(*parquet_parts)
+    parquet_path_literal = _escape_sql_single_quotes(
+        _escape_format_braces(parquet_path)
+    )
+    tbl_a = f"{table}_a"
+    tbl_b = f"{table}_b"
+
+    live = _get_live_backing_table(table)
+    target = tbl_b if live == tbl_a else tbl_a
+
+    log.info(f"Loading into {target} (live={live or 'none'})")
+    target_ddl = ddl.replace(table, target)
+    execute_postgres_sql(f"DROP TABLE IF EXISTS {target} CASCADE", target_ddl)
+
+    source_table_pattern = rf"\bpg\.{re.escape(table)}\b"
+    if not re.search(source_table_pattern, insert_sql_template):
+        raise ValueError(
+            f"Insert template must contain pg.{table} so loads can be redirected "
+            "to the inactive A/B backing table."
+        )
+    target_insert = re.sub(source_table_pattern, f"pg.{target}", insert_sql_template)
+    with get_duckdb_connection() as con, attach_postgres(con):
+        log.info(f"Loading {target} from {parquet_path} (no secondary indexes)")
+        con.execute(target_insert.format(path=parquet_path_literal))
+        row_count = con.execute(f"SELECT count(*) FROM pg.{target}").fetchone()[0]
+
+    if indexes:
+        target_indexes = indexes.replace(table, target)
+        log.info(f"Building secondary indexes on {target}")
+        execute_postgres_sql(target_indexes)
+
+    log.info(f"Swapping view {table} → {target} ({row_count:,} rows)")
+    execute_postgres_sql(
+        f"DROP VIEW IF EXISTS public.{table}",
+        f"DROP TABLE IF EXISTS public.{table} CASCADE",
+        f"CREATE VIEW {table} AS SELECT * FROM {target}",
+    )
+    if live:
+        execute_postgres_sql(f"DROP TABLE IF EXISTS {live} CASCADE")
+
+    log.info(f"Loaded {row_count:,} rows into {table}")
+    return row_count
+
+
+# -- DDL / inserts -------------------------------------------------------------
+
+_BIOPROJECT_DDL = """
+CREATE TABLE IF NOT EXISTS bioproject (
+    accession TEXT PRIMARY KEY,
+    name TEXT,
+    title TEXT,
+    release_date TEXT,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+)
+"""
+
+_BIOPROJECT_INSERT = """
+INSERT INTO pg.bioproject (accession, name, title, release_date, data)
+SELECT accession, name, title, release_date, to_json({{
+    accession: accession, name: name, title: title,
+    description: description, release_date: release_date,
+    data_types: data_types, publications: publications,
+    external_links: external_links, locus_tags: locus_tags
+}})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_BIOSAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS biosample (
+    accession TEXT PRIMARY KEY,
+    sra_sample_id TEXT,
+    organism TEXT,
+    tax_id INTEGER,
+    submission_date DATE,
+    last_update DATE,
+    is_reference BOOLEAN,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_BIOSAMPLE_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_biosample_organism ON biosample (organism);
+CREATE INDEX IF NOT EXISTS ix_biosample_tax_id ON biosample (tax_id);
+CREATE INDEX IF NOT EXISTS ix_biosample_submission_date ON biosample (submission_date);
+CREATE INDEX IF NOT EXISTS ix_biosample_sra_sample_id ON biosample (sra_sample_id);
+"""
+
+_BIOSAMPLE_INSERT = """
+INSERT INTO pg.biosample (accession, sra_sample_id, organism, tax_id, submission_date, last_update, data)
+SELECT
+    accession, sra_sample, taxonomy_name, taxon_id,
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update AS DATE),
+    to_json({{
+        accession: accession, id: id, title: title,
+        description: description, taxonomy_name: taxonomy_name,
+        taxon_id: taxon_id, sra_sample: sra_sample,
+        dbgap: dbgap, gsm: gsm, model: model,
+        submission_date: submission_date, last_update: last_update,
+        publication_date: publication_date, access: access,
+        attribute_recs: attribute_recs, attributes: attributes,
+        id_recs: id_recs, ids: ids
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_SRA_STUDY_DDL = """
+CREATE TABLE IF NOT EXISTS sra_study (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    study_type TEXT,
+    title TEXT,
+    bioproject TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_SRA_STUDY_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_sra_study_organism ON sra_study (organism);
+CREATE INDEX IF NOT EXISTS ix_sra_study_study_type ON sra_study (study_type);
+CREATE INDEX IF NOT EXISTS ix_sra_study_bioproject ON sra_study (bioproject);
+"""
+
+_SRA_STUDY_INSERT = """
+INSERT INTO pg.sra_study (accession, study_type, title, bioproject, data)
+SELECT
+    accession, study_type, title, bioproject,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        description: description, abstract: abstract,
+        study_type: study_type, center_name: center_name,
+        broker_name: broker_name, bioproject: bioproject,
+        geo: geo, identifiers: identifiers,
+        attributes: attributes, xrefs: xrefs,
+        pubmed_ids: pubmed_ids
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_SRA_SAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS sra_sample (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    tax_id INTEGER,
+    biosample TEXT,
+    title TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_SRA_SAMPLE_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_sra_sample_organism ON sra_sample (organism);
+CREATE INDEX IF NOT EXISTS ix_sra_sample_tax_id ON sra_sample (tax_id);
+CREATE INDEX IF NOT EXISTS ix_sra_sample_biosample ON sra_sample (biosample);
+"""
+
+_SRA_SAMPLE_INSERT = """
+INSERT INTO pg.sra_sample (accession, organism, tax_id, biosample, title, data)
+SELECT
+    accession, organism, taxon_id, biosample, title,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        organism: organism, taxon_id: taxon_id,
+        description: description, biosample: biosample,
+        identifiers: identifiers, attributes: attributes,
+        xrefs: xrefs
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_SRA_EXPERIMENT_DDL = """
+CREATE TABLE IF NOT EXISTS sra_experiment (
+    accession TEXT PRIMARY KEY,
+    library_strategy TEXT,
+    library_source TEXT,
+    platform TEXT,
+    instrument_model TEXT,
+    sample_accession TEXT,
+    study_accession TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_SRA_EXPERIMENT_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_library_strategy ON sra_experiment (library_strategy);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_library_source ON sra_experiment (library_source);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_platform ON sra_experiment (platform);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_sample_accession ON sra_experiment (sample_accession);
+CREATE INDEX IF NOT EXISTS ix_sra_experiment_study_accession ON sra_experiment (study_accession);
+"""
+
+_SRA_EXPERIMENT_INSERT = """
+INSERT INTO pg.sra_experiment (accession, library_strategy, library_source, platform, instrument_model, sample_accession, study_accession, data)
+SELECT
+    accession, library_strategy, library_source, platform,
+    instrument_model, sample_accession, study_accession,
+    to_json({{
+        accession: accession, alias: alias, title: title,
+        design: design, center_name: center_name,
+        study_accession: study_accession,
+        sample_accession: sample_accession,
+        platform: platform, instrument_model: instrument_model,
+        library_name: library_name,
+        library_construction_protocol: library_construction_protocol,
+        library_layout: library_layout,
+        library_strategy: library_strategy,
+        library_source: library_source,
+        library_selection: library_selection,
+        identifiers: identifiers, attributes: attributes,
+        xrefs: xrefs, reads: reads
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_SRA_RUN_DDL = """
+CREATE TABLE IF NOT EXISTS sra_run (
+    accession TEXT PRIMARY KEY,
+    experiment_accession TEXT,
+    total_spots INTEGER,
+    total_bases BIGINT,
+    published DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_SRA_RUN_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_sra_run_experiment_accession ON sra_run (experiment_accession);
+CREATE INDEX IF NOT EXISTS ix_sra_run_published ON sra_run (published);
+"""
+
+_SRA_RUN_INSERT = """
+INSERT INTO pg.sra_run (accession, experiment_accession, data)
+SELECT
+    accession, experiment_accession,
+    to_json({{
+        accession: accession, alias: alias,
+        experiment_accession: experiment_accession,
+        title: title, identifiers: identifiers,
+        attributes: attributes, qualities: qualities
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_GEO_SERIES_DDL = """
+CREATE TABLE IF NOT EXISTS geo_series (
+    accession TEXT PRIMARY KEY,
+    title TEXT,
+    organism TEXT,
+    series_type TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_GEO_SERIES_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_geo_series_organism ON geo_series (organism);
+CREATE INDEX IF NOT EXISTS ix_geo_series_series_type ON geo_series (series_type);
+CREATE INDEX IF NOT EXISTS ix_geo_series_submission_date ON geo_series (submission_date);
+"""
+
+_GEO_SERIES_INSERT = """
+INSERT INTO pg.geo_series (accession, title, organism, series_type, submission_date, last_update, data)
+SELECT
+    accession, title, sample_organism[1], type[1],
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update_date AS DATE),
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        summary: summary, overall_design: overall_design,
+        type: type, contact: contact,
+        pubmed_id: pubmed_id, relation: relation,
+        sample_id: sample_id, platform_id: platform_id,
+        sample_organism: sample_organism,
+        platform_organism: platform_organism,
+        supplemental_files: supplemental_files,
+        subseries: subseries, bioprojects: bioprojects,
+        sra_studies: sra_studies, contributor: contributor
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_GEO_SAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS geo_sample (
+    accession TEXT PRIMARY KEY,
+    organism TEXT,
+    platform_id TEXT,
+    series_id TEXT,
+    title TEXT,
+    submission_date DATE,
+    last_update DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_GEO_SAMPLE_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_geo_sample_organism ON geo_sample (organism);
+CREATE INDEX IF NOT EXISTS ix_geo_sample_platform_id ON geo_sample (platform_id);
+CREATE INDEX IF NOT EXISTS ix_geo_sample_series_id ON geo_sample (series_id);
+"""
+
+_GEO_SAMPLE_INSERT = """
+INSERT INTO pg.geo_sample (accession, platform_id, title, submission_date, last_update, data)
+SELECT
+    accession, platform_id, title,
+    TRY_CAST(submission_date AS DATE),
+    TRY_CAST(last_update_date AS DATE),
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        type: type, description: description,
+        platform_id: platform_id, channel_count: channel_count,
+        channels: channels, contact: contact,
+        biosample: biosample, sra_experiment: sra_experiment,
+        library_source: library_source,
+        data_processing: data_processing,
+        supplemental_files: supplemental_files,
+        contributor: contributor
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_GEO_PLATFORM_DDL = """
+CREATE TABLE IF NOT EXISTS geo_platform (
+    accession TEXT PRIMARY KEY,
+    title TEXT,
+    organism TEXT,
+    technology TEXT,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+)
+"""
+
+_GEO_PLATFORM_INSERT = """
+INSERT INTO pg.geo_platform (accession, title, organism, technology, data)
+SELECT
+    accession, title, organism, technology,
+    to_json({{
+        accession: accession, title: title, status: status,
+        submission_date: submission_date,
+        last_update_date: last_update_date,
+        organism: organism, technology: technology,
+        description: description, distribution: distribution,
+        manufacturer: manufacturer, data_row_count: data_row_count,
+        contact: contact, contributor: contributor,
+        relation: relation
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+_PUBMED_DDL = """
+CREATE TABLE IF NOT EXISTS pubmed_article (
+    pmid INTEGER PRIMARY KEY,
+    title TEXT,
+    journal TEXT,
+    pub_date DATE,
+    data JSONB NOT NULL,
+    _loaded_at TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_PUBMED_INDEXES = """
+CREATE INDEX IF NOT EXISTS ix_pubmed_article_journal ON pubmed_article (journal);
+CREATE INDEX IF NOT EXISTS ix_pubmed_article_pub_date ON pubmed_article (pub_date);
+"""
+
+_PUBMED_INSERT = """
+INSERT INTO pg.pubmed_article (pmid, title, journal, pub_date, data)
+SELECT
+    CAST(pmid AS INTEGER), title, journal,
+    TRY_CAST(pubdate AS DATE),
+    to_json({{
+        pmid: pmid, title: title, journal: journal,
+        pubdate: pubdate, abstract: abstract,
+        authors: authors, mesh_terms: mesh_terms,
+        publication_types: publication_types,
+        keywords: keywords, doi: doi,
+        pmc: pmc, issue: issue, pages: pages,
+        "references": "references",
+        languages: languages,
+        chemical_list: chemical_list,
+        grant_ids: grant_ids,
+        country: country, medline_ta: medline_ta
+    }})::TEXT AS data
+FROM read_parquet('{path}')
+"""
+
+
+# -- Tasks ---------------------------------------------------------------------
+
+
+@task(retries=1, retry_delay_seconds=60)
+def bioproject_postgres() -> int:
+    return _load(
+        table="bioproject",
+        ddl=_BIOPROJECT_DDL,
+        parquet_parts=("bioproject", "parquet", "bioprojects.parquet"),
+        insert_sql_template=_BIOPROJECT_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def biosample_postgres() -> int:
+    return _load(
+        table="biosample",
+        ddl=_BIOSAMPLE_DDL,
+        indexes=_BIOSAMPLE_INDEXES,
+        parquet_parts=("biosample", "parquet", "biosamples.parquet"),
+        insert_sql_template=_BIOSAMPLE_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_study_postgres() -> int:
+    return _load(
+        table="sra_study",
+        ddl=_SRA_STUDY_DDL,
+        indexes=_SRA_STUDY_INDEXES,
+        parquet_parts=("sra", "parquet", "sra_studies.parquet"),
+        insert_sql_template=_SRA_STUDY_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_sample_postgres() -> int:
+    return _load(
+        table="sra_sample",
+        ddl=_SRA_SAMPLE_DDL,
+        indexes=_SRA_SAMPLE_INDEXES,
+        parquet_parts=("sra", "parquet", "sra_samples.parquet"),
+        insert_sql_template=_SRA_SAMPLE_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_experiment_postgres() -> int:
+    return _load(
+        table="sra_experiment",
+        ddl=_SRA_EXPERIMENT_DDL,
+        indexes=_SRA_EXPERIMENT_INDEXES,
+        parquet_parts=("sra", "parquet", "sra_experiments.parquet"),
+        insert_sql_template=_SRA_EXPERIMENT_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def sra_run_postgres() -> int:
+    return _load(
+        table="sra_run",
+        ddl=_SRA_RUN_DDL,
+        indexes=_SRA_RUN_INDEXES,
+        parquet_parts=("sra", "parquet", "sra_runs.parquet"),
+        insert_sql_template=_SRA_RUN_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_series_postgres() -> int:
+    return _load(
+        table="geo_series",
+        ddl=_GEO_SERIES_DDL,
+        indexes=_GEO_SERIES_INDEXES,
+        parquet_parts=("geo", "parquet", "geo_series.parquet"),
+        insert_sql_template=_GEO_SERIES_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_sample_postgres() -> int:
+    return _load(
+        table="geo_sample",
+        ddl=_GEO_SAMPLE_DDL,
+        indexes=_GEO_SAMPLE_INDEXES,
+        parquet_parts=("geo", "parquet", "geo_samples.parquet"),
+        insert_sql_template=_GEO_SAMPLE_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def geo_platform_postgres() -> int:
+    return _load(
+        table="geo_platform",
+        ddl=_GEO_PLATFORM_DDL,
+        parquet_parts=("geo", "parquet", "geo_platforms.parquet"),
+        insert_sql_template=_GEO_PLATFORM_INSERT,
+    )
+
+
+@task(retries=1, retry_delay_seconds=60)
+def pubmed_postgres() -> int:
+    return _load(
+        table="pubmed_article",
+        ddl=_PUBMED_DDL,
+        indexes=_PUBMED_INDEXES,
+        parquet_parts=("pubmed", "parquet", "pubmed_articles.parquet"),
+        insert_sql_template=_PUBMED_INSERT,
+    )
+
+
+@flow(name="postgres-load")
+def postgres_load_flow() -> None:
+    """Reload every API-serving table from its consolidated parquet."""
+    bioproject_postgres()
+    biosample_postgres()
+    sra_study_postgres()
+    sra_sample_postgres()
+    sra_experiment_postgres()
+    sra_run_postgres()
+    geo_series_postgres()
+    geo_sample_postgres()
+    geo_platform_postgres()
+    pubmed_postgres()
+
+
+if __name__ == "__main__":
+    postgres_load_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/pubmed.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/pubmed.py
@@ -1,0 +1,138 @@
+"""PubMed extract flow.
+
+Partitions are individual PubMed XML files (e.g., `pubmed25n0001`).
+Each file gets a semaphore under `_semaphores/pubmed/{file_id}.json`.
+The flow lists the NCBI FTP, maps an extract task across files whose
+semaphores are missing, and writes one parquet per file.
+"""
+
+import re
+import shutil
+import tempfile
+from datetime import datetime
+from urllib.request import urlretrieve
+
+import pubmed_parser as pp
+import pyarrow as pa
+import pyarrow.parquet as pq
+from omicidx.prefect.config import get_upath
+from omicidx.prefect.semaphore import SemaphoreStore
+from upath import UPath
+
+from prefect import flow, get_run_logger, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+PUBMED_BASE = UPath("https://ftp.ncbi.nlm.nih.gov/pubmed")
+_XML_GZ_RE = re.compile(r"^(pubmed\d+n\d+)\.xml\.gz$")
+
+
+def _list_pubmed_files() -> dict[str, str]:
+    """List PubMed XML files via HTTPS. Returns {partition_key: url_string}."""
+    result: dict[str, str] = {}
+    for subdir in ["baseline", "updatefiles"]:
+        for entry in (PUBMED_BASE / subdir).iterdir():
+            m = _XML_GZ_RE.match(entry.name)
+            if m:
+                result[m.group(1)] = str(entry)
+    return result
+
+
+def _sanitize_utf8(obj):
+    """Recursively replace invalid UTF-8 bytes in any string values."""
+    if isinstance(obj, str):
+        return obj.encode("utf-8", errors="surrogateescape").decode(
+            "utf-8", errors="replace"
+        )
+    if isinstance(obj, dict):
+        return {k: _sanitize_utf8(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_utf8(v) for v in obj]
+    return obj
+
+
+@task(retries=2, retry_delay_seconds=30, task_run_name="pubmed-extract-{key}")
+def extract_pubmed_file(key: str, url: str, force: bool = False) -> dict:
+    log = get_run_logger()
+    sem = SemaphoreStore("pubmed")
+    if not force and sem.exists(key):
+        log.info(f"pubmed/{key}: semaphore exists, skipping")
+        return {"key": key, "skipped": True}
+
+    output_dir = get_upath("pubmed", "raw")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{key}.parquet"
+
+    with (
+        tempfile.NamedTemporaryFile(suffix=".xml.gz") as tmp_xml,
+        tempfile.NamedTemporaryFile(suffix=".parquet") as tmp_parquet,
+    ):
+        log.info(f"Downloading {url}")
+        urlretrieve(str(url), filename=tmp_xml.name)
+
+        log.info(f"Parsing {key}")
+        articles = list(
+            pp.parse_medline_xml(
+                tmp_xml.name,
+                year_info_only=False,
+                nlm_category=True,
+                author_list=True,
+                reference_list=True,
+                parse_downto_mesh_subterms=True,
+            )
+        )
+
+        for obj in articles:
+            obj["_inserted_at"] = datetime.now()
+            obj["_read_from"] = str(url)
+
+        articles = [_sanitize_utf8(a) for a in articles]
+        table = pa.Table.from_pylist(articles)
+        pq.write_table(table, tmp_parquet.name, compression="zstd")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp_parquet.name, "rb") as src, output_path.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+    log.info(f"Wrote {len(articles)} articles to {output_path}")
+    sem.mark_done(
+        key,
+        metadata={
+            "row_count": len(articles),
+            "output_path": str(output_path),
+            "source_url": str(url),
+        },
+    )
+    return {"key": key, "skipped": False, "row_count": len(articles)}
+
+
+@flow(
+    name="pubmed-extract",
+    task_runner=ThreadPoolTaskRunner(max_workers=4),
+)
+def pubmed_extract_flow(force: bool = False) -> None:
+    """Extract every PubMed file whose semaphore is missing.
+
+    Equivalent to the Dagster pubmed_sensor + pubmed_raw pair: the sensor's
+    job (poll FTP, identify new files) is folded into the flow body.
+    """
+    log = get_run_logger()
+    available = _list_pubmed_files()
+    sem = SemaphoreStore("pubmed")
+    done = set() if force else set(sem.list_keys())
+    todo = sorted(set(available) - done)
+    log.info(
+        f"PubMed listing: {len(available)} files total, "
+        f"{len(done)} done, {len(todo)} to extract"
+    )
+
+    futures = []
+    for key in todo:
+        futures.append(
+            extract_pubmed_file.submit(key=key, url=available[key], force=force)
+        )
+    for fut in futures:
+        fut.result()
+
+
+if __name__ == "__main__":
+    pubmed_extract_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sql.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sql.py
@@ -1,0 +1,121 @@
+"""DuckDB build flow.
+
+Builds the omicidx.duckdb file from consolidated parquet views
+(020-050 SQL) and uploads it to R2/S3.
+"""
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import sqlglot
+from omicidx.prefect.config import get_duckdb_connection, get_upath
+
+from prefect import flow, get_run_logger, task
+
+SQL_DIR = Path(__file__).parent.parent / "sql"
+DB_FILE = "omicidx.duckdb"
+
+
+def _list_sql_files() -> list[str]:
+    return sorted(p.name for p in SQL_DIR.glob("*.sql"))
+
+
+def _get_sql(name: str) -> str:
+    path = SQL_DIR / name
+    if not path.exists():
+        available = ", ".join(_list_sql_files())
+        raise FileNotFoundError(f"SQL file '{name}' not found. Available: {available}")
+    return path.read_text()
+
+
+def _run_sql_file(name: str, con: duckdb.DuckDBPyConnection) -> None:
+    log = get_run_logger()
+    sql = _get_sql(name)
+    statements = sqlglot.transpile(sql, read="duckdb")
+    log.info(f"Running {name} ({len(statements)} statements)")
+    for i, stmt in enumerate(statements, 1):
+        preview = stmt[:100].replace("\n", " ")
+        log.info(f"  [{i}/{len(statements)}] {preview}...")
+        con.execute(stmt)
+    log.info(f"Completed {name}")
+
+
+@task(retries=1, retry_delay_seconds=60)
+def build_omicidx_duckdb() -> dict:
+    """Build the omicidx.duckdb file and upload it to R2/S3."""
+    log = get_run_logger()
+    db_path = Path(DB_FILE)
+    if db_path.exists():
+        db_path.unlink()
+
+    summaries: list[dict] = []
+    with get_duckdb_connection(database=DB_FILE) as con:
+        view_files = [f for f in _list_sql_files() if f >= "020"]
+        log.info(f"Building {DB_FILE} from {len(view_files)} SQL files")
+
+        for name in view_files:
+            _run_sql_file(name, con)
+
+        con.execute("DROP TABLE IF EXISTS db_creation_metadata")
+        con.execute("CREATE TABLE db_creation_metadata AS SELECT now() AS created_at")
+
+        for schema in ["main", "geometadb", "sradb"]:
+            try:
+                tables = con.execute(
+                    f"SELECT table_name FROM information_schema.tables "
+                    f"WHERE table_schema = '{schema}'"
+                ).fetchall()
+            except Exception:
+                continue
+
+            for (table,) in tables:
+                qualified = f"{schema}.{table}" if schema != "main" else table
+                try:
+                    count = con.execute(
+                        f"SELECT COUNT(*) FROM {qualified}"
+                    ).fetchone()[0]
+                except Exception:
+                    count = -1
+                summaries.append(
+                    {"schema": schema, "table": table, "row_count": count}
+                )
+
+        for s in summaries:
+            qualified = (
+                f"{s['schema']}.{s['table']}"
+                if s["schema"] != "main"
+                else s["table"]
+            )
+            log.info(f"  {qualified}: {s['row_count']:,} rows")
+
+        metadata = {
+            "created_at": datetime.now().isoformat(),
+            "tables": summaries,
+        }
+        metadata_path = db_path.with_suffix(".metadata.json")
+        metadata_path.write_text(json.dumps(metadata, indent=2))
+
+    s3_path = get_upath("duckdb", "omicidx.duckdb")
+    log.info(f"Uploading {db_path} to {s3_path}")
+    with db_path.open("rb") as src, s3_path.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+
+    total_rows = sum(s["row_count"] for s in summaries if s["row_count"] > 0)
+    return {
+        "sql_files": ", ".join(_list_sql_files()),
+        "table_count": len(summaries),
+        "total_rows": total_rows,
+        "s3_path": str(s3_path),
+    }
+
+
+@flow(name="omicidx-duckdb-build")
+def omicidx_duckdb_flow() -> None:
+    build_omicidx_duckdb()
+
+
+if __name__ == "__main__":
+    omicidx_duckdb_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
@@ -1,0 +1,388 @@
+"""SRA extract flow.
+
+Partitions are SRA mirror files identified by (entity, date, stage). Each
+file gets a semaphore at `_semaphores/sra/{entity}/{date}_{stage}.json`.
+The flow fetches the current-batch listing, then maps an extract task
+across (entity, date, stage) triples, skipping any with a semaphore.
+"""
+
+import datetime
+import gzip
+import re
+import shutil
+import tempfile
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from omicidx.parsers.sra.parser import sra_object_generator
+from omicidx.prefect.config import get_upath
+from omicidx.prefect.semaphore import SemaphoreStore
+from upath import UPath
+
+from prefect import flow, get_run_logger, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+ENTITIES = ["study", "sample", "experiment", "run"]
+
+
+# ---------------------------------------------------------------------------
+# PyArrow schemas (inlined from omicidx-etl to avoid the coupling)
+# ---------------------------------------------------------------------------
+
+
+def _get_pyarrow_schema(entity: str) -> pa.Schema:
+    identifier_type = pa.struct(
+        [("namespace", pa.string()), ("id", pa.string()), ("uuid", pa.string())]
+    )
+    attribute_type = pa.struct([("tag", pa.string()), ("value", pa.string())])
+    xref_type = pa.struct([("db", pa.string()), ("id", pa.string())])
+    file_alternative_type = pa.struct(
+        [
+            ("url", pa.string()),
+            ("free_egress", pa.string()),
+            ("access_type", pa.string()),
+            ("org", pa.string()),
+        ]
+    )
+    file_type = pa.struct(
+        [
+            ("cluster", pa.string()),
+            ("filename", pa.string()),
+            ("url", pa.string()),
+            ("size", pa.int64()),
+            ("date", pa.string()),
+            ("md5", pa.string()),
+            ("sratoolkit", pa.string()),
+            ("alternatives", pa.list_(file_alternative_type)),
+        ]
+    )
+    run_read_type = pa.struct(
+        [
+            ("index", pa.int64()),
+            ("count", pa.int64()),
+            ("mean_length", pa.float64()),
+            ("sd_length", pa.float64()),
+        ]
+    )
+    base_count_type = pa.struct([("base", pa.string()), ("count", pa.int64())])
+    quality_type = pa.struct([("quality", pa.int32()), ("count", pa.int64())])
+    tax_count_entry_type = pa.struct(
+        [
+            ("rank", pa.string()),
+            ("name", pa.string()),
+            ("parent", pa.int32()),
+            ("total_count", pa.int64()),
+            ("self_count", pa.int64()),
+            ("tax_id", pa.int32()),
+        ]
+    )
+    tax_analysis_type = pa.struct(
+        [
+            ("nspot_analyze", pa.int64()),
+            ("total_spots", pa.int64()),
+            ("mapped_spots", pa.int64()),
+            ("tax_counts", pa.list_(tax_count_entry_type)),
+        ]
+    )
+    experiment_read_type = pa.struct(
+        [
+            ("base_coord", pa.int64()),
+            ("read_class", pa.string()),
+            ("read_index", pa.int64()),
+            ("read_type", pa.string()),
+        ]
+    )
+
+    schemas = {
+        "run": pa.schema(
+            [
+                ("accession", pa.string()),
+                ("alias", pa.string()),
+                ("experiment_accession", pa.string()),
+                ("title", pa.string()),
+                ("total_spots", pa.int64()),
+                ("total_bases", pa.int64()),
+                ("size", pa.int64()),
+                ("avg_length", pa.float64()),
+                ("identifiers", pa.list_(identifier_type)),
+                ("attributes", pa.list_(attribute_type)),
+                ("files", pa.list_(file_type)),
+                ("reads", pa.list_(run_read_type)),
+                ("base_counts", pa.list_(base_count_type)),
+                ("qualities", pa.list_(quality_type)),
+                ("tax_analysis", tax_analysis_type),
+            ]
+        ),
+        "study": pa.schema(
+            [
+                ("accession", pa.string()),
+                ("study_accession", pa.string()),
+                ("alias", pa.string()),
+                ("title", pa.string()),
+                ("description", pa.string()),
+                ("abstract", pa.string()),
+                ("study_type", pa.string()),
+                ("center_name", pa.string()),
+                ("broker_name", pa.string()),
+                ("BioProject", pa.string()),
+                ("GEO", pa.string()),
+                ("identifiers", pa.list_(identifier_type)),
+                ("attributes", pa.list_(attribute_type)),
+                ("xrefs", pa.list_(xref_type)),
+                ("pubmed_ids", pa.list_(pa.string())),
+            ]
+        ),
+        "sample": pa.schema(
+            [
+                ("accession", pa.string()),
+                ("alias", pa.string()),
+                ("title", pa.string()),
+                ("organism", pa.string()),
+                ("description", pa.string()),
+                ("taxon_id", pa.int32()),
+                ("geo", pa.string()),
+                ("BioSample", pa.string()),
+                ("identifiers", pa.list_(identifier_type)),
+                ("attributes", pa.list_(attribute_type)),
+                ("xrefs", pa.list_(xref_type)),
+            ]
+        ),
+        "experiment": pa.schema(
+            [
+                ("accession", pa.string()),
+                ("experiment_accession", pa.string()),
+                ("alias", pa.string()),
+                ("title", pa.string()),
+                ("description", pa.string()),
+                ("design", pa.string()),
+                ("center_name", pa.string()),
+                ("study_accession", pa.string()),
+                ("sample_accession", pa.string()),
+                ("platform", pa.string()),
+                ("instrument_model", pa.string()),
+                ("library_name", pa.string()),
+                ("library_construction_protocol", pa.string()),
+                ("library_layout", pa.string()),
+                ("library_layout_orientation", pa.string()),
+                ("library_layout_length", pa.string()),
+                ("library_layout_sdev", pa.string()),
+                ("library_strategy", pa.string()),
+                ("library_source", pa.string()),
+                ("library_selection", pa.string()),
+                ("spot_length", pa.int64()),
+                ("nreads", pa.int64()),
+                ("identifiers", pa.list_(identifier_type)),
+                ("attributes", pa.list_(attribute_type)),
+                ("xrefs", pa.list_(xref_type)),
+                ("reads", pa.list_(experiment_read_type)),
+            ]
+        ),
+    }
+    return schemas[entity]
+
+
+# ---------------------------------------------------------------------------
+# Mirror listing
+# ---------------------------------------------------------------------------
+
+
+def _parse_mirror_entry(url: str) -> dict | None:
+    try:
+        entity = None
+        for e in ENTITIES:
+            if e in url:
+                entity = e
+                break
+        if entity is None:
+            return None
+
+        is_full = "Full" in url
+        match = re.search(r"NCBI_SRA_Mirroring_(\d{8})", url)
+        if not match:
+            return None
+        entry_date = datetime.datetime.strptime(match.group(1), "%Y%m%d").date()
+
+        return {
+            "url": url,
+            "entity": entity,
+            "is_full": is_full,
+            "date": entry_date,
+        }
+    except (ValueError, AttributeError):
+        return None
+
+
+def _get_mirror_entries() -> list[dict]:
+    up = UPath("https://ftp.ncbi.nlm.nih.gov/sra/reports/Mirroring/")
+    all_files = list(reversed([str(f) for f in up.glob("**/*set.xml.gz")]))
+
+    entries: list[dict] = []
+    found_full = False
+    out_of_full = False
+
+    for url in all_files:
+        entry = _parse_mirror_entry(url)
+        if entry is None:
+            continue
+
+        if entry["is_full"] and not found_full:
+            found_full = True
+
+        if found_full and not entry["is_full"]:
+            out_of_full = True
+
+        entry["in_current_batch"] = not out_of_full
+        entries.append(entry)
+
+    return entries
+
+
+def _partition_key(entry: dict) -> str:
+    """Stable key per mirror file: '{date}_{stage}'."""
+    stage = "Full" if entry["is_full"] else "Incremental"
+    return f"{entry['date'].strftime('%Y-%m-%d')}_{stage}"
+
+
+# ---------------------------------------------------------------------------
+# Per-file extract
+# ---------------------------------------------------------------------------
+
+
+def _iter_records_from_url(url: str):
+    up = UPath(url)
+    with up.open("rb") as f_in, gzip.GzipFile(fileobj=f_in, mode="rb") as gz:
+        for obj in sra_object_generator(gz):
+            yield obj.data
+
+
+def _write_parquet_chunks(
+    url: str,
+    entity: str,
+    out_dir: UPath,
+    chunk_size: int = 500_000,
+) -> tuple[int, int]:
+    log = get_run_logger()
+    schema = _get_pyarrow_schema(entity)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    buf: list[dict] = []
+    part = 0
+    total = 0
+
+    def flush() -> None:
+        nonlocal part
+        if not buf:
+            return
+        table = pa.Table.from_pylist(buf, schema=schema)
+        out_path = out_dir / f"data_{part:05d}.parquet"
+
+        with tempfile.NamedTemporaryFile("wb", delete=False, suffix=".parquet") as tmp:
+            tmp_path = tmp.name
+
+        try:
+            pq.write_table(table, tmp_path, compression="zstd")
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(tmp_path, "rb") as src, out_path.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+        finally:
+            UPath(tmp_path).unlink(missing_ok=True)
+
+        part += 1
+        buf.clear()
+
+    log.info(f"Processing {url}")
+    for rec in _iter_records_from_url(url):
+        buf.append(rec)
+        total += 1
+        if len(buf) >= chunk_size:
+            flush()
+            log.info(f"  {entity}: {total:,} records processed so far")
+
+    flush()
+    return total, part
+
+
+@task(retries=2, retry_delay_seconds=60, task_run_name="sra-extract-{entity}-{key}")
+def extract_mirror_file(
+    entity: str,
+    key: str,
+    url: str,
+    date_str: str,
+    stage: str,
+    force: bool = False,
+) -> dict:
+    """Extract a single SRA mirror file to parquet, gated by a semaphore."""
+    log = get_run_logger()
+    sem = SemaphoreStore(f"sra/{entity}")
+
+    if not force and sem.exists(key):
+        log.info(f"sra/{entity}/{key}: semaphore exists, skipping")
+        return {"entity": entity, "key": key, "skipped": True}
+
+    out_dir = get_upath("sra", "raw", entity) / f"date={date_str}" / f"stage={stage}"
+    records, parts = _write_parquet_chunks(url=url, entity=entity, out_dir=out_dir)
+    log.info(f"{entity} {key}: wrote {records:,} records in {parts} parquet parts")
+
+    sem.mark_done(
+        key,
+        metadata={
+            "row_count": records,
+            "parquet_parts": parts,
+            "source_url": url,
+            "output_dir": str(out_dir),
+        },
+    )
+    return {
+        "entity": entity,
+        "key": key,
+        "skipped": False,
+        "row_count": records,
+        "parquet_parts": parts,
+    }
+
+
+@task
+def get_mirror_listing() -> list[dict]:
+    """Fetch the SRA mirror listing for the current batch."""
+    log = get_run_logger()
+    entries = _get_mirror_entries()
+    current = [e for e in entries if e["in_current_batch"]]
+    log.info(f"Found {len(entries)} total mirror entries, {len(current)} in current batch")
+    for entity in ENTITIES:
+        n = sum(1 for e in current if e["entity"] == entity)
+        log.info(f"  {entity}: {n} files")
+    return current
+
+
+@flow(
+    name="sra-extract",
+    task_runner=ThreadPoolTaskRunner(max_workers=4),
+)
+def sra_extract_flow(force: bool = False) -> None:
+    """Extract every current-batch SRA mirror file to parquet.
+
+    Each (entity, date, stage) triple is one partition. Semaphores live
+    under `_semaphores/sra/{entity}/{date}_{stage}.json`. Pass force=True
+    to re-extract every partition regardless.
+    """
+    entries = get_mirror_listing()
+    futures = []
+    for entry in entries:
+        key = _partition_key(entry)
+        stage = "Full" if entry["is_full"] else "Incremental"
+        futures.append(
+            extract_mirror_file.submit(
+                entity=entry["entity"],
+                key=key,
+                url=entry["url"],
+                date_str=entry["date"].strftime("%Y-%m-%d"),
+                stage=stage,
+                force=force,
+            )
+        )
+    for fut in futures:
+        fut.result()
+
+
+if __name__ == "__main__":
+    sra_extract_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/semaphore.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/semaphore.py
@@ -1,0 +1,83 @@
+"""Semaphore-file partition tracking.
+
+Replaces Dagster's built-in partition state with marker files written to
+storage. For each (namespace, key) pair we maintain a JSON file at
+`{PUBLISH_ROOT}/_semaphores/{namespace}/{key}.json` containing the
+completion timestamp and any caller-supplied metadata.
+
+Flows check `exists()` before running work for a partition and call
+`mark_done()` once the partition output is durably written. Idempotent
+re-runs become "skip if semaphore exists"; backfills become "clear the
+semaphores you want to redo, then re-run".
+
+The semaphore namespace mirrors the path layout (e.g., `sra/study`,
+`geo/gse`, `pubmed`, `ebi_biosample`) so they're easy to enumerate.
+"""
+
+import json
+from datetime import UTC, datetime
+
+import orjson
+from omicidx.prefect.config import get_upath
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class SemaphoreStore:
+    """File-backed completion markers for a single partition namespace."""
+
+    def __init__(self, namespace: str) -> None:
+        cleaned = namespace.strip("/")
+        if not cleaned:
+            raise ValueError("Namespace cannot be empty")
+        self.namespace = cleaned
+
+    def _path(self, key: str):
+        if not key or "/" in key:
+            raise ValueError(f"Invalid partition key {key!r} (no slashes allowed)")
+        return get_upath("_semaphores", *self.namespace.split("/"), f"{key}.json")
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).exists()
+
+    def mark_done(self, key: str, metadata: dict | None = None) -> None:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "namespace": self.namespace,
+            "key": key,
+            "completed_at": _now_iso(),
+            "metadata": metadata or {},
+        }
+        with path.open("wb") as f:
+            f.write(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+
+    def read(self, key: str) -> dict | None:
+        path = self._path(key)
+        if not path.exists():
+            return None
+        with path.open("rb") as f:
+            return json.loads(f.read())
+
+    def clear(self, key: str) -> bool:
+        path = self._path(key)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def list_keys(self) -> list[str]:
+        """Return the partition keys that have been marked done."""
+        root = get_upath("_semaphores", *self.namespace.split("/"))
+        if not root.exists():
+            return []
+        return sorted(p.stem for p in root.iterdir() if p.suffix == ".json")
+
+    def clear_all(self) -> int:
+        """Remove every semaphore in this namespace. Returns count removed."""
+        keys = self.list_keys()
+        for k in keys:
+            self.clear(k)
+        return len(keys)

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/010_raw_to_parquet.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/010_raw_to_parquet.sql
@@ -1,0 +1,309 @@
+--------
+--
+-- GEO Parquet Files
+--
+--------
+
+
+copy (
+    select accession.accession as accession
+    from read_parquet('r2://omicidx/geo/raw/gse_with_rna_seq_counts.parquet')
+    order by accession
+) to 'r2://omicidx/geo/parquet/geo_series_with_rnaseq_counts.parquet' (format parquet, compression zstd);
+
+select count(*) from read_parquet('r2://omicidx/geo/parquet/geo_series_with_rnaseq_counts.parquet');
+
+copy (
+    select
+        trim(title) as title,
+        trim(status) as status,
+        submission_date,
+        last_update_date,
+        trim(accession) as accession,
+        contact,
+        trim(organism) as organism,
+        sample_id,
+        series_id,
+        trim(technology) as technology,
+        trim(description) as description,
+        trim(distribution) as distribution,
+        manufacturer,
+        data_row_count,
+        contributor,
+        relation,
+        trim(manufacture_protocol) as manufacture_protocol
+    from read_ndjson_auto('r2://omicidx/geo/raw/gpl/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
+    order by accession
+) to 'r2://omicidx/geo/parquet/geo_platforms.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/geo/parquet/geo_platforms.parquet');
+
+copy (
+    select
+        trim(title) as title,
+        trim(status) as status,
+        submission_date,
+        last_update_date,
+        trim(accession) as accession,
+        subseries,
+        bioprojects,
+        sra_studies,
+        contact,
+        type,
+        trim(summary) as summary,
+        relation,
+        pubmed_id,
+        sample_id,
+        sample_taxid,
+        sample_organism,
+        platform_id,
+        platform_taxid,
+        platform_organism,
+        supplemental_files,
+        trim(overall_design) as overall_design,
+        contributor
+    from read_ndjson_auto('r2://omicidx/geo/raw/gse/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
+    order by accession
+) to 'r2://omicidx/geo/parquet/geo_series.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/geo/parquet/geo_series.parquet');
+
+copy (
+    select
+        trim(title) as title,
+        trim(status) as status,
+        submission_date,
+        last_update_date,
+        trim(type) as type,
+        trim(anchor) as anchor,
+        contact,
+        trim(description) as description,
+        trim(accession) as accession,
+        biosample,
+        tag_count,
+        tag_length,
+        trim(platform_id) as platform_id,
+        trim(hyb_protocol) as hyb_protocol,
+        channel_count,
+        trim(scan_protocol) as scan_protocol,
+        data_row_count,
+        library_source,
+        sra_experiment,
+        trim(data_processing) as data_processing,
+        supplemental_files,
+        channels,
+        contributor
+    from read_ndjson_auto('r2://omicidx/geo/raw/gsm/**/*.ndjson.gz')
+    qualify row_number() over (partition by accession order by last_update_date desc nulls last) = 1
+    order by accession
+) to 'r2://omicidx/geo/parquet/geo_samples.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/geo/parquet/geo_samples.parquet');
+
+--------
+--
+-- SRA Parquet Files
+--
+--------
+
+copy (
+    select
+        trim("Accession") as accession,
+        trim("Submission") as submission,
+        trim("Status") as status,
+        "Updated" as updated,
+        "Published" as published,
+        "Received" as received,
+        trim("Type") as type,
+        trim("Center") as center,
+        trim("Visibility") as visibility,
+        trim("Alias") as alias,
+        trim("Experiment") as experiment,
+        trim("Sample") as sample,
+        trim("Study") as study,
+        "Loaded" as loaded,
+        "Spots" as spots,
+        "Bases" as bases,
+        trim("Md5sum") as md5sum,
+        trim("BioSample") as biosample,
+        trim("BioProject") as bioproject,
+        trim("ReplacedBy") as replacedby
+    from read_csv_auto(
+            'https://ftp.ncbi.nlm.nih.gov/sra/reports/Metadata/SRA_Accessions.tab',
+            nullstr = '-'
+        )
+) to 'r2://omicidx/sra/parquet/sra_accessions.parquet' (format parquet, compression zstd);
+
+select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_accessions.parquet');
+
+copy (
+    select
+        trim(accession) as accession,
+        trim(alias) as alias,
+        trim(experiment_accession) as experiment_accession,
+        trim(title) as title,
+        identifiers,
+        attributes,
+        qualities
+    from read_parquet('r2://omicidx/sra/raw/run/**/*parquet')
+    order by accession
+) to 'r2://omicidx/sra/parquet/sra_runs.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_runs.parquet');
+
+copy (
+    select
+        trim(accession) as accession,
+        trim(experiment_accession) as experiment_accession,
+        trim(alias) as alias,
+        trim(title) as title,
+        trim(design) as design,
+        trim(center_name) as center_name,
+        trim(study_accession) as study_accession,
+        trim(sample_accession) as sample_accession,
+        trim(platform) as platform,
+        trim(instrument_model) as instrument_model,
+        trim(library_name) as library_name,
+        trim(library_construction_protocol) as library_construction_protocol,
+        trim(library_layout) as library_layout,
+        trim(library_layout_length) as library_layout_length,
+        trim(library_layout_sdev) as library_layout_sdev,
+        trim(library_strategy) as library_strategy,
+        trim(library_source) as library_source,
+        trim(library_selection) as library_selection,
+        spot_length,
+        nreads,
+        identifiers,
+        attributes,
+        xrefs,
+        reads
+    from read_parquet('r2://omicidx/sra/raw/experiment/**/*parquet')
+    order by accession
+) to 'r2://omicidx/sra/parquet/sra_experiments.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_experiments.parquet');
+
+copy (
+    select
+        trim(accession) as accession,
+        trim(alias) as alias,
+        trim(title) as title,
+        trim(organism) as organism,
+        trim(description) as description,
+        taxon_id,
+        trim("BioSample") as biosample,
+        identifiers,
+        attributes,
+        xrefs
+    from read_parquet('r2://omicidx/sra/raw/sample/**/*parquet')
+    order by accession
+) to 'r2://omicidx/sra/parquet/sra_samples.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_samples.parquet');
+
+copy (
+    select
+        trim(accession) as accession,
+        trim(study_accession) as study_accession,
+        trim(alias) as alias,
+        trim(title) as title,
+        trim(description) as description,
+        trim(abstract) as abstract,
+        trim(study_type) as study_type,
+        trim(center_name) as center_name,
+        trim(broker_name) as broker_name,
+        trim("BioProject") as bioproject,
+        trim("GEO") as geo,
+        identifiers,
+        attributes,
+        xrefs,
+        pubmed_ids
+    from read_parquet('r2://omicidx/sra/raw/study/**/*parquet')
+    order by accession
+) to 'r2://omicidx/sra/parquet/sra_studies.parquet' (format parquet, compression zstd);
+
+
+select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_studies.parquet');
+
+--------
+--
+-- BioProject and BioSample Parquet Files
+--
+--------
+
+
+copy (
+    select
+        trim(submission_date) as submission_date,
+        trim(last_update) as last_update,
+        trim(publication_date) as publication_date,
+        trim(access) as access,
+        trim(id) as id,
+        trim(accession) as accession,
+        id_recs,
+        ids,
+        trim(sra_sample) as sra_sample,
+        trim(dbgap) as dbgap,
+        trim(gsm) as gsm,
+        trim(title) as title,
+        trim(description) as description,
+        trim(taxonomy_name) as taxonomy_name,
+        taxon_id,
+        attribute_recs,
+        attributes,
+        trim(model) as model
+    from read_ndjson_auto(
+            'r2://omicidx/biosample/biosample/raw/biosample/raw/biosample.jsonl.gz',
+            maximum_object_size = 1000000000
+        )
+) to 'r2://omicidx/biosample/parquet/biosamples.parquet' (format parquet, compression zstd);
+
+select count(*) from read_parquet('r2://omicidx/biosample/parquet/biosamples.parquet');
+
+--------
+--
+-- PubMed Parquet Files
+--
+--------
+
+copy (
+    select
+        trim(title) as title,
+        trim(issue) as issue,
+        trim(pages) as pages,
+        trim(abstract) as abstract,
+        trim(journal) as journal,
+        authors,
+        trim(pubdate) as pubdate,
+        trim(pmid) as pmid,
+        trim(mesh_terms) as mesh_terms,
+        trim(publication_types) as publication_types,
+        trim(chemical_list) as chemical_list,
+        trim(keywords) as keywords,
+        trim(doi) as doi,
+        "references",
+        trim(languages) as languages,
+        trim(vernacular_title) as vernacular_title,
+        trim(date_completed) as date_completed,
+        trim(date_revised) as date_revised,
+        trim(pmc) as pmc,
+        trim(other_id) as other_id,
+        trim(medline_ta) as medline_ta,
+        trim(nlm_unique_id) as nlm_unique_id,
+        trim(issn_linking) as issn_linking,
+        trim(country) as country,
+        grant_ids
+    from read_parquet('r2://omicidx/pubmed/raw/*.parquet')
+    where delete is not true
+    order by pmid
+) to 'r2://omicidx/pubmed/parquet/pubmed_articles.parquet' (format parquet, compression zstd);
+
+select count(*) from read_parquet('r2://omicidx/pubmed/parquet/pubmed_articles.parquet');

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
@@ -1,0 +1,85 @@
+create or replace view src_geo_series as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series.parquet')
+);
+
+create or replace view src_geo_samples as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_samples.parquet')
+);
+
+create or replace view src_geo_series_with_rnaseq_counts as (
+    select accession
+    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series_with_rnaseq_counts.parquet')
+);
+
+create or replace view src_geo_platforms as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_platforms.parquet')
+);
+
+create or replace view src_sra_accessions as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet')
+);
+
+-----
+--
+-- SRA Views
+--
+-----
+
+create or replace view src_sra_studies as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_studies.parquet')
+);
+
+create or replace view src_sra_samples as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_samples.parquet')
+);
+
+create or replace view src_sra_experiments as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_experiments.parquet')
+);
+
+create or replace view src_sra_runs as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_runs.parquet')
+);
+
+create or replace view src_sra_accessions as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet')
+);
+
+-----
+--
+-- BioSample and BioProject Views
+--
+-----
+
+create or replace view src_biosamples as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/biosample/parquet/biosamples.parquet')
+);
+
+create or replace view src_bioprojects as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/bioproject/parquet/bioprojects.parquet')
+);
+
+-----
+--
+-- PubMed Views
+--
+-----
+
+create or replace view src_pubmed_articles as (
+    select *
+    from read_parquet('https://data-omicidx.cancerdatasci.org/pubmed/parquet/pubmed_articles.parquet')
+);
+
+-- End of base parquet views
+

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/030_staging_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/030_staging_views.sql
@@ -1,0 +1,141 @@
+-- Staging views: cleaned, typed, and normalized
+--
+-- These stg_* views:
+--   1. Apply type corrections and coercions
+--   2. Normalize column names (lowercase, consistent naming)
+--   3. Enrich with accession-level statistics where needed
+--
+-- Note: The parquet files are already deduplicated by the ETL pipeline.
+
+-----
+-- SRA Staging Views
+-----
+
+CREATE OR REPLACE VIEW stg_sra_studies AS
+SELECT
+    accession,
+    alias,
+    title,
+    description,
+    abstract,
+    study_type,
+    center_name,
+    broker_name,
+    bioproject AS bioproject_accession,
+    geo AS geo_accession,
+    identifiers,
+    attributes,
+    xrefs,
+    pubmed_ids
+FROM src_sra_studies;
+
+CREATE OR REPLACE VIEW stg_sra_samples AS
+SELECT
+    accession,
+    alias,
+    title,
+    organism,
+    description,
+    taxon_id,
+    biosample AS biosample_accession,
+    identifiers,
+    attributes,
+    xrefs
+FROM src_sra_samples;
+
+CREATE OR REPLACE VIEW stg_sra_experiments AS
+SELECT
+    accession,
+    alias,
+    title,
+    design,
+    center_name,
+    study_accession,
+    sample_accession,
+    platform,
+    instrument_model,
+    library_name,
+    library_construction_protocol,
+    library_layout,
+    TRY_CAST(library_layout_length AS INTEGER) AS library_layout_length,
+    TRY_CAST(library_layout_sdev AS DOUBLE) AS library_layout_sdev,
+    library_strategy,
+    library_source,
+    library_selection,
+    spot_length,
+    nreads,
+    identifiers,
+    attributes,
+    xrefs,
+    reads
+FROM src_sra_experiments;
+
+CREATE OR REPLACE VIEW stg_sra_runs AS
+SELECT
+    r.accession,
+    r.alias,
+    r.experiment_accession,
+    r.title,
+    a.spots AS total_spots,
+    a.bases AS total_bases,
+    r.identifiers,
+    r.attributes,
+    r.qualities
+FROM src_sra_runs r
+LEFT JOIN src_sra_accessions a ON r.accession = a.accession;
+
+-----
+-- GEO Staging Views
+-----
+
+CREATE OR REPLACE VIEW stg_geo_series AS
+SELECT * FROM src_geo_series;
+
+CREATE OR REPLACE VIEW stg_geo_samples AS
+SELECT * FROM src_geo_samples;
+
+CREATE OR REPLACE VIEW stg_geo_platforms AS
+SELECT * FROM src_geo_platforms;
+
+-----
+-- Biosample/Bioproject Staging Views
+-----
+
+CREATE OR REPLACE VIEW stg_biosamples AS
+SELECT * FROM src_biosamples;
+
+CREATE OR REPLACE VIEW stg_bioprojects AS
+SELECT * FROM src_bioprojects;
+
+-----
+-- PubMed Staging Views
+-----
+
+CREATE OR REPLACE VIEW stg_pubmed_articles AS
+SELECT DISTINCT ON (pmid)
+    pmid,
+    title,
+    abstract,
+    journal,
+    medline_ta,
+    country,
+    issn_linking,
+    nlm_unique_id,
+    pubdate,
+    date_completed,
+    date_revised,
+    doi,
+    pmc,
+    issue,
+    pages,
+    languages,
+    vernacular_title,
+    other_id,
+    authors,
+    mesh_terms,
+    publication_types,
+    chemical_list,
+    keywords,
+    "references",
+    grant_ids
+FROM src_pubmed_articles;

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/040_geometadb_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/040_geometadb_views.sql
@@ -1,0 +1,141 @@
+create schema IF NOT EXISTS geometadb;
+
+use geometadb;
+
+create or replace view gsm as (
+SELECT
+    title,
+    accession AS gsm,
+    platform_id AS gpl,
+    status,
+    submission_date,
+    last_update_date,
+    type,
+    channels[1].source_name AS source_name_ch1,
+    channels[1].organism AS organism_ch1,
+    channels[1].characteristics AS characteristics_ch1,
+    channels[1].molecule AS molecule_ch1,
+    channels[1].label AS label_ch1,
+    channels[1].treatment_protocol AS treatment_protocol_ch1,
+    channels[1].extract_protocol AS extract_protocol_ch1,
+    channels[1].label_protocol AS label_protocol_ch1,
+    channels[2].source_name AS source_name_ch2,
+    channels[2].organism AS organism_ch2,
+    channels[2].characteristics AS characteristics_ch2,
+    channels[2].molecule AS molecule_ch2,
+    channels[2].label AS label_ch2,
+    channels[2].treatment_protocol AS treatment_protocol_ch2,
+    channels[2].extract_protocol AS extract_protocol_ch2,
+    channels[2].label_protocol AS label_protocol_ch2,
+    channels AS channel_records,
+    hyb_protocol,
+    description,
+    data_processing,
+    contact."name"."first" || ' ' || contact."name"."last" AS contact,
+    supplemental_files,
+    data_row_count,
+    channel_count
+FROM src_geo_samples
+);
+
+create or replace view gse as (
+WITH has_geo_computed_rnaseq AS (
+    SELECT
+        r.accession
+    FROM
+        src_geo_series_with_rnaseq_counts r
+)
+SELECT
+    g.accession AS gse,
+    title,
+    status,
+    submission_date,
+    last_update_date,
+    summary,
+    pubmed_id,
+    type,
+    contributor,
+    'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' || g.accession AS web_link,
+    overall_design,
+    contact.country AS contact_country,
+    contact.email AS contact_email,
+    contact."name"."first" AS contact_first_name,
+    contact.institute AS contact_institute,
+    contact."name"."last" AS contact_last_name,
+    contact."name"."first" || ' ' || contact."name"."last" AS contact,
+    supplemental_files,
+
+    -- Indicates if the GEO Series has associated ncbi-supplied RNA-Seq data
+    CASE WHEN h.accession IS NOT NULL THEN TRUE ELSE FALSE END AS has_geo_computed_rnaseq
+FROM src_geo_series g
+LEFT JOIN has_geo_computed_rnaseq h
+    ON g.accession = h.accession
+);
+
+create or replace view gpl as (
+    SELECT
+    title,
+    accession AS gpl,
+    status,
+    submission_date,
+    last_update_date,
+    technology,
+    distribution,
+    organism,
+    manufacturer,
+    manufacture_protocol,
+    description,
+    'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' || accession AS web_link,
+    contact."name"."first" || ' ' || contact."name"."last" AS contact,
+    data_row_count
+FROM src_geo_platforms
+);
+
+------
+--
+--  JOIN tables
+--
+------
+
+create or replace view gse_gpl as (
+SELECT DISTINCT
+    accession AS gpl,
+    UNNEST(series_id) AS gse
+FROM src_geo_platforms
+);
+
+
+create or replace view gse_gsm as (
+SELECT DISTINCT
+    accession AS gse,
+    UNNEST(sample_id) AS gsm
+FROM src_geo_series
+);
+
+create or replace view geo_supplemental_files as (
+WITH supp_file AS (
+    SELECT
+        accession,
+        'gse' AS accession_type,
+        UNNEST(supplemental_files) AS supplemental_file
+    FROM src_geo_series
+
+    UNION ALL
+
+    SELECT
+        accession,
+        'gsm' AS accession_type,
+        UNNEST(supplemental_files) AS supplemental_file
+    FROM src_geo_samples
+)
+SELECT
+    accession,
+    accession_type,
+    regexp_replace(supplemental_file, '^ftp://', 'https://') AS supplemental_file,
+    regexp_extract(supplemental_file, '[^/]+$') AS filename
+FROM supp_file
+WHERE supplemental_file != 'NONE'
+);
+
+-- End of geometadb views
+use main;

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/050_sradb_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/050_sradb_views.sql
@@ -1,0 +1,299 @@
+-- SRAdb-compatible views over OmicIDX parquet files
+-- These views approximate the functionality of the original SRAmetadb.sqlite
+-- using DuckDB as the engine and parquet files as the backend storage.
+--
+-- Usage:
+--   1. First run 020_base_parquet_views.sql to create the src_* views
+--   2. Then run 030_staging_views.sql to create the stg_* views (deduplicated)
+--   3. Then run this file to create the sradb schema and views
+--
+-- The views are designed to be compatible with existing SRAdb queries where possible.
+
+CREATE SCHEMA IF NOT EXISTS sradb;
+
+USE sradb;
+
+-----
+-- study table
+-- Maps: stg_sra_studies -> sradb.study
+-----
+CREATE OR REPLACE VIEW study AS
+SELECT
+    ROW_NUMBER() OVER (ORDER BY accession) AS study_ID,
+    alias AS study_alias,
+    accession AS study_accession,
+    title AS study_title,
+    study_type,
+    abstract AS study_abstract,
+    broker_name,
+    center_name,
+    bioproject_accession AS center_project_name,
+    description AS study_description,
+    NULL AS related_studies,
+    NULL AS primary_study,
+    NULL AS sra_link,
+    NULL AS study_url_link,
+    NULL AS xref_link,
+    NULL AS study_entrez_link,
+    NULL AS ddbj_link,
+    NULL AS ena_link,
+    -- Convert attributes array to JSON string for compatibility
+    CAST(attributes AS VARCHAR) AS study_attribute,
+    NULL AS submission_accession,
+    NULL AS sradb_updated
+FROM main.stg_sra_studies;
+
+-----
+-- sample table
+-- Maps: stg_sra_samples -> sradb.sample
+-----
+CREATE OR REPLACE VIEW sample AS
+SELECT
+    ROW_NUMBER() OVER (ORDER BY accession) AS sample_ID,
+    alias AS sample_alias,
+    accession AS sample_accession,
+    NULL AS broker_name,
+    NULL AS center_name,
+    taxon_id,
+    organism AS scientific_name,
+    NULL AS common_name,
+    NULL AS anonymized_name,
+    NULL AS individual_name,
+    description,
+    NULL AS sra_link,
+    NULL AS sample_url_link,
+    NULL AS xref_link,
+    NULL AS sample_entrez_link,
+    NULL AS ddbj_link,
+    NULL AS ena_link,
+    CAST(attributes AS VARCHAR) AS sample_attribute,
+    NULL AS submission_accession,
+    NULL AS sradb_updated
+FROM main.stg_sra_samples;
+
+-----
+-- experiment table
+-- Maps: stg_sra_experiments -> sradb.experiment
+-----
+CREATE OR REPLACE VIEW experiment AS
+SELECT
+    ROW_NUMBER() OVER (ORDER BY accession) AS experiment_ID,
+    NULL AS bamFile,
+    NULL AS fastqFTP,
+    alias AS experiment_alias,
+    accession AS experiment_accession,
+    NULL AS broker_name,
+    center_name,
+    title,
+    NULL AS study_name,
+    study_accession,
+    design AS design_description,
+    NULL AS sample_name,
+    sample_accession,
+    NULL AS sample_member,
+    library_name,
+    library_strategy,
+    library_source,
+    library_selection,
+    library_layout,
+    NULL AS targeted_loci,
+    library_construction_protocol,
+    spot_length,
+    NULL AS adapter_spec,
+    CAST(reads AS VARCHAR) AS read_spec,
+    platform,
+    instrument_model,
+    NULL AS platform_parameters,
+    NULL AS sequence_space,
+    NULL AS base_caller,
+    NULL AS quality_scorer,
+    NULL AS number_of_levels,
+    NULL AS multiplier,
+    NULL AS qtype,
+    NULL AS sra_link,
+    NULL AS experiment_url_link,
+    NULL AS xref_link,
+    NULL AS experiment_entrez_link,
+    NULL AS ddbj_link,
+    NULL AS ena_link,
+    CAST(attributes AS VARCHAR) AS experiment_attribute,
+    NULL AS submission_accession,
+    NULL AS sradb_updated
+FROM main.stg_sra_experiments;
+
+-----
+-- run table
+-- Maps: stg_sra_runs -> sradb.run
+-----
+CREATE OR REPLACE VIEW run AS
+SELECT
+    ROW_NUMBER() OVER (ORDER BY accession) AS run_ID,
+    NULL AS bamFile,
+    alias AS run_alias,
+    accession AS run_accession,
+    NULL AS broker_name,
+    NULL AS instrument_name,
+    NULL AS run_date,
+    NULL AS run_file,
+    NULL AS run_center,
+    NULL AS total_data_blocks,
+    experiment_accession,
+    NULL AS experiment_name,
+    NULL AS sra_link,
+    NULL AS run_url_link,
+    NULL AS xref_link,
+    NULL AS run_entrez_link,
+    NULL AS ddbj_link,
+    NULL AS ena_link,
+    CAST(attributes AS VARCHAR) AS run_attribute,
+    NULL AS submission_accession,
+    NULL AS sradb_updated
+FROM main.stg_sra_runs;
+
+-----
+-- sra table (denormalized join of all entities)
+-- This is the main table that SRAdb users typically query
+-- Maps: stg_sra_runs + experiments + samples + studies -> sradb.sra
+-----
+CREATE OR REPLACE VIEW sra AS
+SELECT
+    ROW_NUMBER() OVER (ORDER BY r.accession) AS sra_ID,
+    NULL AS SRR_bamFile,
+    NULL AS SRX_bamFile,
+    NULL AS SRX_fastqFTP,
+    -- Run fields
+    ROW_NUMBER() OVER (ORDER BY r.accession) AS run_ID,
+    r.alias AS run_alias,
+    r.accession AS run_accession,
+    NULL AS run_date,
+    NULL AS updated_date,
+    r.total_spots AS spots,
+    r.total_bases AS bases,
+    NULL AS run_center,
+    NULL AS experiment_name,
+    NULL AS run_url_link,
+    NULL AS run_entrez_link,
+    CAST(r.attributes AS VARCHAR) AS run_attribute,
+    -- Experiment fields
+    ROW_NUMBER() OVER (ORDER BY e.accession) AS experiment_ID,
+    e.alias AS experiment_alias,
+    e.accession AS experiment_accession,
+    e.title AS experiment_title,
+    NULL AS study_name,
+    NULL AS sample_name,
+    e.design AS design_description,
+    e.library_name,
+    e.library_strategy,
+    e.library_source,
+    e.library_selection,
+    e.library_layout,
+    e.library_construction_protocol,
+    NULL AS adapter_spec,
+    CAST(e.reads AS VARCHAR) AS read_spec,
+    e.platform,
+    e.instrument_model,
+    NULL AS instrument_name,
+    NULL AS platform_parameters,
+    NULL AS sequence_space,
+    NULL AS base_caller,
+    NULL AS quality_scorer,
+    NULL AS number_of_levels,
+    NULL AS multiplier,
+    NULL AS qtype,
+    NULL AS experiment_url_link,
+    NULL AS experiment_entrez_link,
+    CAST(e.attributes AS VARCHAR) AS experiment_attribute,
+    -- Sample fields
+    ROW_NUMBER() OVER (ORDER BY sa.accession) AS sample_ID,
+    sa.alias AS sample_alias,
+    sa.accession AS sample_accession,
+    sa.taxon_id,
+    NULL AS common_name,
+    NULL AS anonymized_name,
+    NULL AS individual_name,
+    sa.description,
+    NULL AS sample_url_link,
+    NULL AS sample_entrez_link,
+    CAST(sa.attributes AS VARCHAR) AS sample_attribute,
+    -- Study fields
+    ROW_NUMBER() OVER (ORDER BY st.accession) AS study_ID,
+    st.alias AS study_alias,
+    st.accession AS study_accession,
+    st.title AS study_title,
+    st.study_type,
+    st.abstract AS study_abstract,
+    st.bioproject_accession AS center_project_name,
+    st.description AS study_description,
+    NULL AS study_url_link,
+    NULL AS study_entrez_link,
+    CAST(st.attributes AS VARCHAR) AS study_attribute,
+    NULL AS related_studies,
+    NULL AS primary_study,
+    -- Submission fields (not available in current data)
+    NULL AS submission_ID,
+    NULL AS submission_accession,
+    NULL AS submission_comment,
+    NULL AS submission_center,
+    NULL AS submission_lab,
+    NULL AS submission_date,
+    NULL AS sradb_updated
+FROM main.stg_sra_runs r
+LEFT JOIN main.stg_sra_experiments e ON r.experiment_accession = e.accession
+LEFT JOIN main.stg_sra_samples sa ON e.sample_accession = sa.accession
+LEFT JOIN main.stg_sra_studies st ON e.study_accession = st.accession;
+
+-----
+-- Convenience views for common queries
+-----
+
+-- View to get run info with study context (common use case)
+CREATE OR REPLACE VIEW run_with_study AS
+SELECT
+    r.accession AS run_accession,
+    r.total_spots,
+    r.total_bases,
+    e.accession AS experiment_accession,
+    e.library_strategy,
+    e.library_source,
+    e.library_selection,
+    e.library_layout,
+    e.platform,
+    e.instrument_model,
+    sa.accession AS sample_accession,
+    sa.organism,
+    sa.taxon_id,
+    st.accession AS study_accession,
+    st.title AS study_title,
+    st.study_type,
+    st.bioproject_accession AS BioProject
+FROM main.stg_sra_runs r
+LEFT JOIN main.stg_sra_experiments e ON r.experiment_accession = e.accession
+LEFT JOIN main.stg_sra_samples sa ON e.sample_accession = sa.accession
+LEFT JOIN main.stg_sra_studies st ON e.study_accession = st.accession;
+
+-- View for RNA-seq experiments (common filter)
+CREATE OR REPLACE VIEW rnaseq_runs AS
+SELECT *
+FROM run_with_study
+WHERE library_strategy = 'RNA-Seq';
+
+-- View for WGS experiments
+CREATE OR REPLACE VIEW wgs_runs AS
+SELECT *
+FROM run_with_study
+WHERE library_strategy = 'WGS';
+
+-- View for human samples
+CREATE OR REPLACE VIEW human_runs AS
+SELECT *
+FROM run_with_study
+WHERE taxon_id = 9606;
+
+-- View for mouse samples
+CREATE OR REPLACE VIEW mouse_runs AS
+SELECT *
+FROM run_with_study
+WHERE taxon_id = 10090;
+
+-- End of SRAdb-compatible views
+use main;

--- a/packages/omicidx-prefect/tests/test_flows.py
+++ b/packages/omicidx-prefect/tests/test_flows.py
@@ -1,0 +1,97 @@
+"""Smoke tests: every flow module imports cleanly and registers its flows.
+
+A failure here means the worker would fail to load the deployment.
+"""
+
+import importlib
+
+FLOW_MODULES = [
+    "omicidx.prefect.flows.sra",
+    "omicidx.prefect.flows.geo",
+    "omicidx.prefect.flows.biosample",
+    "omicidx.prefect.flows.pubmed",
+    "omicidx.prefect.flows.ebi_biosample",
+    "omicidx.prefect.flows.consolidate",
+    "omicidx.prefect.flows.postgres",
+    "omicidx.prefect.flows.sql",
+    "omicidx.prefect.flows.main",
+]
+
+
+def test_flow_modules_import(monkeypatch):
+    # Settings() reads env vars at import time via the config helpers, but
+    # only when actually called. Stub the required vars so any module-level
+    # config access works on import.
+    monkeypatch.setenv("PUBLISH_ROOT", "s3://test-bucket")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "x")
+    monkeypatch.setenv("S3_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv("S3_REGION", "auto")
+    for name in FLOW_MODULES:
+        mod = importlib.import_module(name)
+        assert mod is not None
+
+
+def test_semaphore_namespace_validation():
+    import pytest
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    with pytest.raises(ValueError):
+        SemaphoreStore("")
+    with pytest.raises(ValueError):
+        SemaphoreStore("///")
+
+    store = SemaphoreStore("sra/study")
+    assert store.namespace == "sra/study"
+
+
+def test_semaphore_key_validation(monkeypatch, tmp_path):
+    """Keys must not contain slashes."""
+    monkeypatch.setenv("PUBLISH_ROOT", str(tmp_path))
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "x")
+    monkeypatch.setenv("S3_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv("S3_REGION", "auto")
+    # Bust the lru_cache so the test env sticks
+    from omicidx.prefect import config
+
+    config.settings.cache_clear()
+
+    import pytest
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    store = SemaphoreStore("test")
+    with pytest.raises(ValueError):
+        store.exists("bad/key")
+    with pytest.raises(ValueError):
+        store.exists("")
+
+
+def test_semaphore_roundtrip(monkeypatch, tmp_path):
+    """Write a semaphore, read it back, list, then clear."""
+    monkeypatch.setenv("PUBLISH_ROOT", str(tmp_path))
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "x")
+    monkeypatch.setenv("S3_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv("S3_REGION", "auto")
+    from omicidx.prefect import config
+
+    config.settings.cache_clear()
+
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    store = SemaphoreStore("sra/study")
+    assert not store.exists("2024-09-13_Full")
+    store.mark_done("2024-09-13_Full", metadata={"row_count": 42})
+    assert store.exists("2024-09-13_Full")
+
+    payload = store.read("2024-09-13_Full")
+    assert payload["namespace"] == "sra/study"
+    assert payload["key"] == "2024-09-13_Full"
+    assert payload["metadata"]["row_count"] == 42
+    assert "completed_at" in payload
+
+    assert store.list_keys() == ["2024-09-13_Full"]
+    assert store.clear("2024-09-13_Full") is True
+    assert not store.exists("2024-09-13_Full")
+    assert store.clear("2024-09-13_Full") is False

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "omicidx-dagster",
     "omicidx-etl",
     "omicidx-parsers",
+    "omicidx-prefect",
 ]
 
 [manifest.dependency-groups]
@@ -182,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -193,6 +203,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
+name = "amplitude-analytics"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/b23d28b1c405c22a25375e2c638c8cdcd054cbc4b43b76cf77bd358a0540/amplitude_analytics-1.2.3.tar.gz", hash = "sha256:4c9525847c391c19675d6e026f4601c27204ffeec71cb92252770d84d4538404", size = 22413, upload-time = "2026-03-31T18:33:20.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/56/83af6ef6a8bac9fdf2059de0276008e9eab40a315b8b732eba466bf6cc74/amplitude_analytics-1.2.3-py3-none-any.whl", hash = "sha256:ba2092c1d37ce8a2e3f69d023da145f4e322d02429e20436a5227178b1e594e9", size = 24762, upload-time = "2026-03-31T18:33:19.032Z" },
 ]
 
 [[package]]
@@ -247,6 +266,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "apprise"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "click" },
+    { name = "markdown" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/74/9c16829d3e7e45ce7daf1b704687fa4fde7ea00d72eafe8de18c72bf5995/apprise-1.10.0.tar.gz", hash = "sha256:b768f32d99e45ed5f4c3eef1f67903e803c97f97ba61a531a5d0a45d40df90a8", size = 2188611, upload-time = "2026-04-26T14:23:51.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/f9/177a73589d34e676d10bc4c6a8328710e28af5907234e9f25bb149a04eec/apprise-1.10.0-py3-none-any.whl", hash = "sha256:e685303d3568bb7a057d6ddeafd27ee12fff183ca36483ad4bacc0b9b4efa82c", size = 1632292, upload-time = "2026-04-26T14:23:49.28Z" },
 ]
 
 [[package]]
@@ -306,6 +343,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/da/e7908b54e0f8043725a990bf625f2041ecf6bfe8eb7b19407f1c00b630f7/asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308", size = 15627, upload-time = "2023-03-28T17:35:49.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f", size = 10895, upload-time = "2023-03-28T17:35:47.772Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -359,6 +408,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8a/ca724066c32a53fa75f59e0f21aa822fdaa8a0dffa112d223634e3caabf9/async_lru-2.2.0.tar.gz", hash = "sha256:80abae2a237dbc6c60861d621619af39f0d920aea306de34cb992c879e01370c", size = 14654, upload-time = "2026-02-20T19:11:43.848Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/5c/af990f019b8dd11c5492a6371fe74a5b0276357370030b67254a87329944/async_lru-2.2.0-py3-none-any.whl", hash = "sha256:e2c1cf731eba202b59c5feedaef14ffd9d02ad0037fcda64938699f2c380eafe", size = 7890, upload-time = "2026-02-20T19:11:42.273Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -434,6 +492,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -538,6 +605,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/22/7fe08c726a2e3b11a0aef8bf177e83891c9cb2dc1809d35c9ed91a9e60e6/botocore-1.41.5.tar.gz", hash = "sha256:0367622b811597d183bfcaab4a350f0d3ede712031ce792ef183cabdee80d3bf", size = 14668152, upload-time = "2025-11-26T20:27:38.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/4e/21cd0b8f365449f1576f93de1ec8718ed18a7a3bc086dfbdeb79437bba7a/botocore-1.41.5-py3-none-any.whl", hash = "sha256:3fef7fcda30c82c27202d232cfdbd6782cb27f20f8e7e21b20606483e66ee73a", size = 14337008, upload-time = "2025-11-26T20:27:35.208Z" },
+]
+
+[[package]]
+name = "burner-redis"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -714,6 +806,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -741,6 +842,82 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "coolname"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/90/0cb2e364ed736c01790b264a2cafbe7702fc50090337ce37366e03384d20/coolname-4.2.0.tar.gz", hash = "sha256:b0f2d6d4654d627230e143f9efa5c5e1955b11e0cdd54211558c1170496f9f19", size = 38718, upload-time = "2026-04-11T17:26:13.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9f/9aec78a18b64333f9a54d18f9d2f479d51c25bc715dc57e46c12bfd5ce21/coolname-4.2.0-py3-none-any.whl", hash = "sha256:6a67db5e3c3f1b196a9ad4563af118da0d962875ed9b6e8a6dfd96e045847c3a", size = 40130, upload-time = "2026-04-11T17:26:10.382Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -881,6 +1058,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -942,6 +1134,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1012,6 +1218,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/0a/6ae31b2914b4dc34243279b2301554bcbc5f1a09ccc82600486c49ab71d1/duckdb-1.4.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0440f59e0cd9936a9ebfcf7a13312eda480c79214ffed3878d75947fc3b7d6d", size = 20435641, upload-time = "2026-01-26T11:50:12.188Z" },
     { url = "https://files.pythonhosted.org/packages/d2/b1/fd5c37c53d45efe979f67e9bd49aaceef640147bb18f0699a19edd1874d6/duckdb-1.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:59c8d76016dde854beab844935b1ec31de358d4053e792988108e995b18c08e7", size = 12762360, upload-time = "2026-01-26T11:50:14.76Z" },
     { url = "https://files.pythonhosted.org/packages/dd/2d/13e6024e613679d8a489dd922f199ef4b1d08a456a58eadd96dc2f05171f/duckdb-1.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:53cd6423136ab44383ec9955aefe7599b3fb3dd1fe006161e6396d8167e0e0d4", size = 13458633, upload-time = "2026-01-26T11:50:17.657Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -1238,6 +1456,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1292,6 +1519,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/49/eb6d2935e27883af92c930ed40cc4c69bcd32c402be43b8ca4ab20510f67/griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92", size = 293757, upload-time = "2026-03-27T11:34:52.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/c0/2bb018eecf9a83c68db9cd9fffd9dab25f102ad30ed869451046e46d1187/griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b", size = 5141, upload-time = "2026-03-27T11:34:47.721Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e0/6a7d661d71bb043656a109b91d84a42b5342752542074ec83b16a6eb97f0/griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb", size = 56281, upload-time = "2026-03-27T11:34:50.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/90d93356c88ac34c20cb5edffca68138df55ca9bbd1a06eccfbcec8fdbe5/griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0", size = 9500, upload-time = "2026-03-27T11:34:48.81Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1368,6 +1630,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1715,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "humanfriendly"
 version = "10.0"
@@ -1441,6 +1730,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1581,6 +1888,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2-humanize-extension"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanize" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/77/0bba383819dd4e67566487c11c49479ced87e77c3285d8e7f7a3401cf882/jinja2_humanize_extension-0.4.0.tar.gz", hash = "sha256:e7d69b1c20f32815bbec722330ee8af14b1287bb1c2b0afa590dbf031cadeaa0", size = 4746, upload-time = "2023-09-01T12:52:42.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b4/08c9d297edd5e1182506edecccbb88a92e1122a057953068cadac420ca5d/jinja2_humanize_extension-0.4.0-py3-none-any.whl", hash = "sha256:b6326e2da0f7d425338bebf58848e830421defbce785f12ae812e65128518156", size = 4769, upload-time = "2023-09-01T12:52:41.098Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1596,6 +1916,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/77/e8/a3f261a66e4663f22700bc8a17c08cb83e91fbf086726e7a228398968981/json5-0.13.0.tar.gz", hash = "sha256:b1edf8d487721c0bf64d83c28e91280781f6e21f4a797d3261c7c828d4c165bf", size = 52441, upload-time = "2026-01-01T19:42:14.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/9e/038522f50ceb7e74f1f991bf1b699f24b0c2bbe7c390dd36ad69f4582258/json5-0.13.0-py3-none-any.whl", hash = "sha256:9a08e1dd65f6a4d4c6fa82d216cf2477349ec2346a38fd70cc11d2557499fbcc", size = 36163, upload-time = "2026-01-01T19:42:13.962Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
 ]
 
 [[package]]
@@ -2079,6 +2411,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -2586,6 +2927,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "omicidx-api"
 version = "0.1.0"
 source = { editable = "packages/omicidx-api" }
@@ -2766,6 +3116,67 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [[package]]
+name = "omicidx-prefect"
+version = "0.1.0"
+source = { editable = "packages/omicidx-prefect" }
+dependencies = [
+    { name = "anyio", extra = ["trio"] },
+    { name = "asyncpg" },
+    { name = "click" },
+    { name = "duckdb" },
+    { name = "httpx" },
+    { name = "omicidx-parsers" },
+    { name = "orjson" },
+    { name = "polars-lts-cpu" },
+    { name = "prefect" },
+    { name = "pubmed-parser" },
+    { name = "pyarrow" },
+    { name = "pydantic-settings" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "s3fs" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlglot" },
+    { name = "tenacity" },
+    { name = "universal-pathlib" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", extras = ["trio"], specifier = ">=4.0" },
+    { name = "asyncpg", specifier = ">=0.30" },
+    { name = "click", specifier = ">=8.0" },
+    { name = "duckdb", specifier = ">=1.4" },
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "omicidx-parsers", editable = "packages/omicidx-parsers" },
+    { name = "orjson", specifier = ">=3.10" },
+    { name = "polars-lts-cpu", specifier = ">=1.32" },
+    { name = "prefect", specifier = ">=3.0" },
+    { name = "pubmed-parser", git = "https://github.com/seandavi/pubmed_parser" },
+    { name = "pyarrow", specifier = ">=20.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "python-dateutil", specifier = ">=2.9" },
+    { name = "python-dotenv", specifier = ">=1.1" },
+    { name = "s3fs", specifier = ">=2023.0.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "sqlglot", specifier = ">=27.0" },
+    { name = "tenacity", specifier = ">=8.0" },
+    { name = "universal-pathlib", specifier = ">=0.2.2" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2856,11 +3267,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -2888,6 +3299,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pendulum"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/27/a4be6ec12161b503dd036f8d7cc57f8626170ae31bb298038be9af0001ce/pendulum-3.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5d775cc608c909ad415c8e789c84a9f120bb6a794c4215b2d8d910893cf0ec6a", size = 337923, upload-time = "2026-01-30T11:20:51.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/2a214e18355ec2a6ce3f683a97eecdb6050866ff3a6cf165d411450aeb1b/pendulum-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8de794a7f665aebc8c1ba4dd4b05ab8fe1a36ce9c0498366adf1d1edd79b2686", size = 327379, upload-time = "2026-01-30T11:20:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/7392e58ebc1d9e70b987dc8bb0c89710b47ac8125067efe7aa4c420b616f/pendulum-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bac7df7696e1c942e17c0556b3a7bcdd1d7aa5b24faee7620cb071e754a0622", size = 340115, upload-time = "2026-01-30T11:20:54.635Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/80de84c5ca1a3e4f7f3b75090c9b61b6dbb6d095e302ee592cebbaf0bbfb/pendulum-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0f6a8a04475d9cba26ce701e7d66d266fd97227f2f5f499270eba04be1c7e9", size = 373969, upload-time = "2026-01-30T11:20:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/f7b4c1818927ab394a2a0a9b7011f360a0a75839a22678833c5bc0a84183/pendulum-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c352c63c1ff05f2198409b28498d7158547a8be23e1fbd4aa2cf5402fb239b55", size = 379058, upload-time = "2026-01-30T11:20:57.618Z" },
+    { url = "https://files.pythonhosted.org/packages/36/94/9947cf710620afcc68751683f2f8de88d902505e7c13c0349d7e9d362f97/pendulum-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de8c1ad1d1aa7d4ceae341528bab35a0f8c88a5aa63f2f5d84e16b517d1b32c2", size = 348403, upload-time = "2026-01-30T11:20:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/0e6ba0bb00fa57907af2a3fca8643bded5dba1e87072d50673776a0d6ed2/pendulum-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1ba955511c12fec2252038b0c866c25c0c30b720bf74d3023710f121e42b1498", size = 517457, upload-time = "2026-01-30T11:21:01.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fe/dae5fbfe67bd41d943def0ad8f1e7f6988aa8e527255e433cd7c494f9ad5/pendulum-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4115bf364a2ec6d5ddc476751ceaa4164a04f2c15589f0d29aa210ddb784b15d", size = 561103, upload-time = "2026-01-30T11:21:03.924Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a0/8f646160b98abfc19152505af19bd643a4279ec2bdbe0959f16b7025fc6b/pendulum-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:4151a903356413fdd9549de0997b708fb95a214ed97803ffb479ffd834088378", size = 260595, upload-time = "2026-01-30T11:21:05.495Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/feead7af9ded7a13f2d798fb6573e70f469113eafcd8cc8f59671584ca3e/pendulum-3.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:acfdee9ddc56053cb7c8c075afbfde0857322d09e56a56195b9cd127fae87e4c", size = 255382, upload-time = "2026-01-30T11:21:06.847Z" },
+    { url = "https://files.pythonhosted.org/packages/41/56/dd0ea9f97d25a0763cda09e2217563b45714786118d8c68b0b745395d6eb/pendulum-3.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bf0b489def51202a39a2a665dcc4162d5e46934a740fe4c4fe3068979610156c", size = 337830, upload-time = "2026-01-30T11:21:08.298Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/98/83d62899bf7226fc12396de4bc1fb2b5da27e451c7c60790043aaf8b4731/pendulum-3.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:937a529aa302efa18dcf25e53834964a87ffb2df8f80e3669ab7757a6126beaf", size = 327574, upload-time = "2026-01-30T11:21:09.715Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fa/ff2aa992b23f0543c709b1a3f3f9ed760ec71fd02c8bb01f93bf008b52e4/pendulum-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85c7689defc65c4dc29bf257f7cca55d210fabb455de9476e1748d2ab2ae80d7", size = 339891, upload-time = "2026-01-30T11:21:11.089Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4e/25b4fa11d19503d50d7b52d7ef943c0f20fd54422aaeb9e38f588c815c50/pendulum-3.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e216e5a412563ea2ecf5de467dcf3d02717947fcdabe6811d5ee360726b02b", size = 373726, upload-time = "2026-01-30T11:21:12.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/30/0acad6396c4e74e5c689aa4f0b0c49e2ecdcfce368e7b5bf35ca1c0fc61a/pendulum-3.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a2af22eeec438fbaac72bb7fba783e0950a514fba980d9a32db394b51afccec", size = 379827, upload-time = "2026-01-30T11:21:14.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f7/e6a2fdf2a23d59b4b48b8fa89e8d4bf2dd371aea2c6ba8fcecec20a4acb9/pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3159cceb54f5aa8b85b141c7f0ce3fac8bdd1ffdc7c79e67dca9133eac7c4d11", size = 348921, upload-time = "2026-01-30T11:21:15.816Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f2/c15fa7f9ad4e181aa469b6040b574988bd108ccdf4ae509ad224f9e4db44/pendulum-3.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c39ea5e9ffa20ea8bae986d00e0908bd537c8468b71d6b6503ab0b4c3d76e0ea", size = 517188, upload-time = "2026-01-30T11:21:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c7/5f80b12ee88ec26e930c3a5a602608a63c29cf60c81a0eb066d583772550/pendulum-3.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5afc753e570cce1f44197676371f68953f7d4f022303d141bb09f804d5fe6d7", size = 561833, upload-time = "2026-01-30T11:21:19.232Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/1ac481626cb63db751f6281e294661947c1f0321ebe5d1c532a3b51a8006/pendulum-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd55c12560816d9122ca2142d9e428f32c0c083bf77719320b1767539c7a3a3b", size = 258725, upload-time = "2026-01-30T11:21:20.558Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/50b0398d7d027eb70a3e1e336de7b6e599c6b74431cb7d3863287e1292bb/pendulum-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:faef52a7ed99729f0838353b956f3fabf6c550c062db247e9e2fc2b48fcb9457", size = 253089, upload-time = "2026-01-30T11:21:22.497Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8c/400c8b8dbd7524424f3d9902ded64741e82e5e321d1aabbd68ade89e71cf/pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3", size = 337820, upload-time = "2026-01-30T11:21:24.305Z" },
+    { url = "https://files.pythonhosted.org/packages/59/38/7c16f26cc55d9206d71da294ce6857d0da381e26bc9e0c2a069424c2b173/pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075", size = 327551, upload-time = "2026-01-30T11:21:25.747Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/f36ec5d56d55104232380fdbf84ff53cc05607574af3cbdc8a43991ac8a7/pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354", size = 339894, upload-time = "2026-01-30T11:21:27.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/b9a1e546519c3a92d5bc17787cea925e06a20def2ae344fa136d2fc40338/pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d", size = 373766, upload-time = "2026-01-30T11:21:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a6/6471ab87ae2260594501f071586a765fc894817043b7d2d4b04e2eff4f31/pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e", size = 379837, upload-time = "2026-01-30T11:21:30.637Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/0ba0c14e862388f7b822626e6e989163c23bebe7f96de5ec4b207cbe7c3d/pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004", size = 348904, upload-time = "2026-01-30T11:21:32.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/34/df922c7c0b12719589d4954bfa5bdca9e02bcde220f5c5c1838a87118960/pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621", size = 517173, upload-time = "2026-01-30T11:21:34.428Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/3b9e061eeee97b72a47c1434ee03f6d85f0284d9285d92b12b0fff2d19ac/pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a", size = 561744, upload-time = "2026-01-30T11:21:35.861Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7e/f12fdb6070b7975c1fcfa5685dbe4ab73c788878a71f4d1d7e3c87979e37/pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4", size = 258746, upload-time = "2026-01-30T11:21:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/5abd872056357f069ae34a9b24a75ac58e79092d16201d779a8dd31386bb/pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122", size = 253028, upload-time = "2026-01-30T11:21:39.381Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/5b9cc823862450910bcb2c7cdc6884c0939b268639146d30e4a4f55eb1f1/pendulum-3.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c17ac069e88c5a1e930a5ae0ef17357a14b9cc5a28abadda74eaa8106d241c8e", size = 338281, upload-time = "2026-01-30T11:21:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/64a35260f6ac36c0ad50eeb5f1a465b98b0d7603f79a5c2077c41326d639/pendulum-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1fbb540edecb21f8244aebfb05a1f2333ddc6c7819378c099d4a61cc91ae93c", size = 328030, upload-time = "2026-01-30T11:21:42.778Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6b/1140e09310035a2afb05bb90a2b8fbda9d3222e03b92de9533123afe6b65/pendulum-3.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c67fb9a1fe8fc1adae2cc01b0c292b268c12475b4609ff4aed71c9dd367b4d", size = 340206, upload-time = "2026-01-30T11:21:44.148Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4a/a493de56cbc24a64b21ac6ba98513a9ec5c67daa3dba325e39a8e53f30d8/pendulum-3.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:baa9a66c980defda6cfe1275103a94b22e90d83ebd7a84cc961cee6cbd25a244", size = 373976, upload-time = "2026-01-30T11:21:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/f083c4fd1a161d4ab218680cc906338c541497b3098373f2241f58c429cb/pendulum-3.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef8f783fa7a14973b0596d8af2a5b2d90858a55030e9b4c6885eb4284b88314f", size = 380075, upload-time = "2026-01-30T11:21:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/333a0fcb33bf15eb879a46a11ce6300c1698a141e689665fe430783ff8d6/pendulum-3.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d2e9bfb065727d8676e7ada3793b47a24349500a5e9637404355e482c822be", size = 349026, upload-time = "2026-01-30T11:21:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1a/dfb526ec0cba1e7cd6a5e4f4dd64a6ada7428d1449c54b15f7b295f6e122/pendulum-3.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:55d7ba6bb74171c3ee409bf30076ee3a259a3c2bb147ac87ebb76aaa3cf5d3a2", size = 517395, upload-time = "2026-01-30T11:21:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/b4f2b5f1200351c4869b8b46ad5c21019e3dbe0417f5867ae969fad7b5fe/pendulum-3.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:a50d8cf42f06d3d8c3f8bb2a7ac47fa93b5145e69de6a7209be6a47afdd9cf76", size = 561926, upload-time = "2026-01-30T11:21:51.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9e/567376582da58f5fe8e4f579db2bcfbf243cf619a5825bdf1023ad1436b3/pendulum-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e5bbb92b155cd5018b3cf70ee49ed3b9c94398caaaa7ed97fe41e5bb5a968418", size = 258817, upload-time = "2026-01-30T11:21:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/95/67/dfffd7eb50d67fa821cd4d92cf71575ead6162930202bc40dfcedf78c38c/pendulum-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:d53134418e04335c3029a32e9341cccc9b085a28744fb5ee4e6a8f5039363b1a", size = 253292, upload-time = "2026-01-30T11:21:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0d/d5ac8468a1b40f09a62d6e91654088de432367907579dd161c0fb1bdf222/pendulum-3.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9585594d32faa71efa5a78f576f1ee4f79e9c5340d7c6f0cd6c5dfe725effaaa", size = 338760, upload-time = "2026-01-30T11:22:12.225Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/7fa8c8be6caac8e0be78fbe7668df571f44820ed779cb3736fab645fcba8/pendulum-3.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:26401e2de77c437e8f3b6160c08c6c5d45518d906f8f9b48fd7cb5aa0f4e2aff", size = 328333, upload-time = "2026-01-30T11:22:13.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/78/73a1031b7d1bf7986e8e655cea3f018164b3470aecfea25a4074e77dda73/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637e65af042f383a2764a886aa28ccc6f853bf7a142df18e41c720542934c13b", size = 340841, upload-time = "2026-01-30T11:22:15.278Z" },
+    { url = "https://files.pythonhosted.org/packages/49/40/4e36e9074e92b0164c088b9ada3c02bfea386d83e24fa98b30fe9b6e61a8/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6e46c28f4d067233c4a4c42748f4ffa641d9289c09e0e81488beb6d4b3fab51", size = 348959, upload-time = "2026-01-30T11:22:16.718Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/8bf7fcb91b526e1efe17d047faa845709b88800fff915ff848ff26054293/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:71d46bcc86269f97bfd8c5f1475d55e717696a0a010b1871023605ca94624031", size = 518102, upload-time = "2026-01-30T11:22:18.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884, upload-time = "2026-01-30T11:22:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236, upload-time = "2026-01-30T11:22:21.059Z" },
+    { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
 ]
 
 [[package]]
@@ -2948,6 +3419,73 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prefect"
+version = "3.6.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "amplitude-analytics" },
+    { name = "anyio" },
+    { name = "apprise" },
+    { name = "asgi-lifespan" },
+    { name = "asyncpg" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "coolname" },
+    { name = "cryptography" },
+    { name = "dateparser" },
+    { name = "docker" },
+    { name = "exceptiongroup" },
+    { name = "fastapi" },
+    { name = "fsspec" },
+    { name = "graphviz" },
+    { name = "griffe" },
+    { name = "httpcore" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "humanize" },
+    { name = "jinja2" },
+    { name = "jinja2-humanize-extension" },
+    { name = "jsonpatch" },
+    { name = "jsonschema" },
+    { name = "opentelemetry-api" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pendulum", marker = "python_full_version < '3.13'" },
+    { name = "pluggy" },
+    { name = "prometheus-client" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "pydocket" },
+    { name = "python-dateutil" },
+    { name = "python-slugify" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "readchar" },
+    { name = "rfc3339-validator" },
+    { name = "rich" },
+    { name = "ruamel-yaml" },
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "semver" },
+    { name = "sniffio" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+    { name = "whenever", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/25/aa44e02889c26ed38dcd3ce1572c64f477d29a5eee0289415ba0ae576afb/prefect-3.6.19.tar.gz", hash = "sha256:277020b73a3fff57b013756083be34747a7e4ed7be49c2ae267f85a9af7651a4", size = 11223526, upload-time = "2026-02-24T18:36:54.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/6b/c8dac4d7d9b3ff74fdc554b405f794975e69adc6cb4748d8a472ce8421aa/prefect-3.6.19-py3-none-any.whl", hash = "sha256:6ba4a8a65366de48f653b841627d0f4c9fae28ac8b2843c3eb9a3ac0c0c1a74c", size = 11983967, upload-time = "2026-02-24T18:36:51.969Z" },
 ]
 
 [[package]]
@@ -3143,6 +3681,27 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+memory = [
+    { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3319,6 +3878,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3355,6 +3927,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/8a/2c7f7ad656d22371a596d232fc140327b958d7f1d491b889632ea0cb7e87/pydoc_markdown-4.8.2.tar.gz", hash = "sha256:fb6c927e31386de17472d42f9bd3d3be2905977d026f6216881c65145aa67f0b", size = 44506, upload-time = "2023-06-26T12:37:01.152Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/5a/ce0b056d9a95fd0c06a6cfa5972477d79353392d19230c748a7ba5a9df04/pydoc_markdown-4.8.2-py3-none-any.whl", hash = "sha256:203f74119e6bb2f9deba43d452422de7c8ec31955b61e0620fa4dd8c2611715f", size = 67830, upload-time = "2023-06-26T12:36:59.502Z" },
+]
+
+[[package]]
+name = "pydocket"
+version = "0.20.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/4e/4994a407ae4e7561e84881b1edda8fedb58e7078c693845bdd1b66a73765/pydocket-0.20.3.tar.gz", hash = "sha256:ecf923cbcc8f7f26c7e76cad03a03d179536e4d947f322a89e9cc899a2631f72", size = 381244, upload-time = "2026-05-19T13:42:50.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/18/2cf2fcabdc99c858401b7a44b7577e7a3002648048bb4d77517c22d8264d/pydocket-0.20.3-py3-none-any.whl", hash = "sha256:ba009b53270c5e677175def464fed2137d6289a9c9f57f376885f6c27f24a466", size = 110356, upload-time = "2026-05-19T13:42:47.816Z" },
 ]
 
 [[package]]
@@ -3440,12 +4036,24 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2026.2"
+name = "python-slugify"
+version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -3601,6 +4209,27 @@ wheels = [
 ]
 
 [[package]]
+name = "readchar"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/49/a10341024c45bed95d13197ec9ef0f4e2fd10b5ca6e7f8d7684d18082398/readchar-4.2.2.tar.gz", hash = "sha256:e3b270fe16fc90c50ac79107700330a133dd4c63d22939f5b03b4f24564d5dd8", size = 9762, upload-time = "2026-04-06T19:45:54.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ca/36133653e00939922dd1416f4c56177361289172a30563fcb9552c9ccde4/readchar-4.2.2-py3-none-any.whl", hash = "sha256:92daf7e42c52b0787e6c75d01ecfb9a94f4ceff3764958b570c1dddedd47b200", size = 9401, upload-time = "2026-04-06T19:45:52.993Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3612,6 +4241,110 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
 ]
 
 [[package]]
@@ -3627,6 +4360,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -3676,15 +4422,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -3796,6 +4542,63 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
+    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
+    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
+    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
+    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
+    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -3832,6 +4635,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/ef/dbee238c6c78275f433742feae2a717df2e7ed151d5e9dc953fc3b075cc6/s3fs-2023.12.2.tar.gz", hash = "sha256:b5ec07062481bbb45cb061b31984c7188d106e292c27033039e024e4ba5740dc", size = 74155, upload-time = "2023-12-11T21:57:24.802Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/d6/b8a748b7d3fc7b0fd2ede1cf26a80281d65cc24d5d56b66c3a4c87e256e2/s3fs-2023.12.2-py3-none-any.whl", hash = "sha256:0d5a99039665f30b2dbee5495de3b299a022d51b3195a9440f5df47c2621b777", size = 28882, upload-time = "2023-12-11T21:57:22.326Z" },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]
@@ -4045,6 +4857,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4054,6 +4875,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -4208,7 +5038,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -4216,9 +5046,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
 ]
 
 [[package]]
@@ -4249,6 +5079,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]
@@ -4574,6 +5425,103 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "whenever"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "tzlocal", marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/9a/6b12d5708a703010877bec0efc5172ae8a851516abc13cd4543ce4d02a20/whenever-0.9.5.tar.gz", hash = "sha256:9d8f2fbc70acdab98a99b81a2ac594ebd4cc68d5b3506b990729a5f0b04d0083", size = 259436, upload-time = "2026-01-11T19:47:51.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/5f/6d450a9d65d2b6d057ee76d33755b16f90216c50fc30822a9ac7e54e48b8/whenever-0.9.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e0f576ef8bfe42a30ee58964aacbe808074af857db2c06e50fd52fbe823f781", size = 465828, upload-time = "2026-01-11T19:47:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7f/68e7ae96d7496fa89b9a734aa7b39b67439a57fae2741d5852d8433086e8/whenever-0.9.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cc287533980f18f0979e43872e744486e9a021ba5712f04e957ca81b411d1d44", size = 438159, upload-time = "2026-01-11T19:47:09.377Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/464eecf15a5b91154b3369e845b84b517190e201c7b2e941cdb072d438f6/whenever-0.9.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f39438186abfe8866f9e2aee02041cb1844d9d6a7e3b099d468ef00a73bdf1fb", size = 451933, upload-time = "2026-01-11T19:45:27.111Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/7bcb3e87905b5d3cd05b3ca5a9641cb31498228d26ca2bc651d48b2c73fe/whenever-0.9.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:80c0f61c3c8489149dd4bb440d18ec36e17e4839faa4dc350a447f620842c43b", size = 497338, upload-time = "2026-01-11T19:45:47.769Z" },
+    { url = "https://files.pythonhosted.org/packages/93/68/cb439086d3666ea4a6ab01b449fea030657920d608f43d28d19d29e2ab05/whenever-0.9.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c639cd6d2e278cfbfd095b32158d7799be7479d4438b68ae46289f9c82781543", size = 485358, upload-time = "2026-01-11T19:46:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/2bbb2bcb4e0669b77b92713a5b4a5e77257dbae5eaf4a3864c51a9ecfdbf/whenever-0.9.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d039e03cbefd69a60886d14b5cb6ffba682bdce983d1eac9d1daa744072aa3e", size = 520113, upload-time = "2026-01-11T19:46:17.931Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/02/9b78a9d606029bcc38192cd2cc3ba01aedd94f80b0c468edda3108bf95b1/whenever-0.9.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0da674f4f5a8a775c7abfec4201c64741a1b932a281b9f3f32e378f5e6d7894", size = 481062, upload-time = "2026-01-11T19:46:46.809Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c1/2cf6e1855ca670f9b3b67ac3dd9c8bc64c0800a7a7a1f4d88f480d2b5fd9/whenever-0.9.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:856223ea8b315bfd19252e72aadc9d0ff3d8d2e40e9824a37ed577193ea7e76b", size = 519304, upload-time = "2026-01-11T19:46:27.734Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/4028de789a3b88e8f143190dc5bc18fbeb82fdbf0e95a245fb0e9dc13ef7/whenever-0.9.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:587d044067b952277440510526319e9b67219112813b03229b7d2930a616f027", size = 636403, upload-time = "2026-01-11T19:45:37.276Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/41b224c6b9eaf1b999557f10f6ba9844d6c1c73b4a5dbb8fd9994c8895c9/whenever-0.9.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3eaa851b6a5cbb56deaf8fe192cf4398f846497bbefb425c19870bd0d62af0aa", size = 768029, upload-time = "2026-01-11T19:45:56.367Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4a/ad6f092c605f2a202170a4ec86003444e8549d2d9ebad4e38e2f0893bb57/whenever-0.9.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:64479b06ab2cbc3a02477857ad2fb8943a4ff8f1480aaa13125080707932f915", size = 730631, upload-time = "2026-01-11T19:46:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/872390afc9d7f7d698b0c52e3f0b4f4a5ba14b29d2f32027eef22d63d555/whenever-0.9.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:926acd3e6a8d37b246df7486e3ab9562c413ed90a814cf137e9eca11c6ec6b13", size = 694050, upload-time = "2026-01-11T19:46:57.695Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/dd/2000edaba7e1874b4c340a4f7b3022c55f0541f99758e3ed92df3719f679/whenever-0.9.5-cp311-cp311-win32.whl", hash = "sha256:1c3ee48230266bc27193586fe77cb2395079de7b3bc0cbff00d87097fc1ec235", size = 413105, upload-time = "2026-01-11T19:47:29.766Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/34/35ba090f384d42e7b203e7c5d467e6a1944c151bb0a040948f91d36d6777/whenever-0.9.5-cp311-cp311-win_amd64.whl", hash = "sha256:283e73a8565c827ff9576926765d3e4f3d41d7dec38e1b63e7faadb5b233ddec", size = 437867, upload-time = "2026-01-11T19:47:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7d/f05ea580a1c99575c82a1b15d6c64826cb0e53101ad06020df109a51aa29/whenever-0.9.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:59c65af262738a9f649e008d51bbba506223ca7a7f2a5c935b9b0975f58227ed", size = 467312, upload-time = "2026-01-11T19:47:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6d/15102f4703ce111b1f1066afb2d62c40575ad2be91c7896442a77bf4d937/whenever-0.9.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a957d5e2bb652cb802eee2e1683c62023a9ba696e82483c4629b829f6c16fb5d", size = 438830, upload-time = "2026-01-11T19:47:10.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cb/a603e92c85b3d70b64380e737d080329fd731d3ab2ef30475d099bb1f85a/whenever-0.9.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5e6da8f343a7522f1b2830b0e365e5417086da7a67d3086fbfc83d332b55c56", size = 453060, upload-time = "2026-01-11T19:45:28.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/36/a9f07ec85ddc415f3500d00acdfeb5b63a6dcaba91f2802e1061f4a32240/whenever-0.9.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:767f34bd6dd209afaebebb481de3af03d9a61271f5455c7e4dffedfac63ed6e9", size = 498406, upload-time = "2026-01-11T19:45:48.771Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f8/bb0891fce7605b44d0dc4d0a09c27dd8408e75e90c1f1adff1a3ef6ab0c0/whenever-0.9.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42d707e3f2c07a0c688c27c16f3e9bbe56551b72ec1fb9bc8df32b8d45e54520", size = 487042, upload-time = "2026-01-11T19:46:08.306Z" },
+    { url = "https://files.pythonhosted.org/packages/66/35/3ea67d9e4fbebb619dc7801d678b3b40408586619a8bf0a18c7d20e9dc91/whenever-0.9.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e0a004b2b143146dbfafcf023b7bf007333e73c2d0955f44762a3131cbfcb47", size = 521880, upload-time = "2026-01-11T19:46:18.987Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5f/24f6c09a4f1e66b9257b88711164cad6262dc8c8d51d1a758d144e26f249/whenever-0.9.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9b760e8968f1d2681687dfd0ac06d7cb310603710faad0b85d3d9b86ac792f3", size = 483374, upload-time = "2026-01-11T19:46:48.425Z" },
+    { url = "https://files.pythonhosted.org/packages/93/af/335af2917c6fdb58fd01dcf4922dd5d251ce70387d9bea60e723d45a01ae/whenever-0.9.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e7fb3da8014c3170b53a629b278105bcb3679c0835db7d88c27798058686181a", size = 521134, upload-time = "2026-01-11T19:46:28.778Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/05/fa3c60413befbd2c5c52fa9c65b840bcb4d73e8ed32e2df69696640481cc/whenever-0.9.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ce9a6d8d05db2aefb13b0f49d4a581b13035f966c967cd3e7f98a2bb6016ab66", size = 636617, upload-time = "2026-01-11T19:45:38.49Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/56/63668cd8ae23c0219e75b254ba926425d44ddb3482f6c95aac30b00cee2f/whenever-0.9.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b9c52bd3ff2246e9c03d8e72c5d28044f35070b7c23d44b93592cd5b61c45f36", size = 769639, upload-time = "2026-01-11T19:45:57.548Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ff/3781f3867897974b39eea74a83f337479d98c76cf74608b8b6fa9c7b59a7/whenever-0.9.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77086386feba0bee7bc030b86e118a521c18b3741ad3c69e0c8e7b601a763a2a", size = 733169, upload-time = "2026-01-11T19:46:38.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/85/09d9e4e17ef78b380e57c6b89274fa37c8b250321d5e09f9efa8a58c941e/whenever-0.9.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:45ae1ce8bbb3668f6281251a0d22ac81bdf563909306b0d69eaa630ceb1051b9", size = 696787, upload-time = "2026-01-11T19:46:58.887Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/96/78408214f359016c0153f103decc6e3566426f809ea0c250d638b4315de6/whenever-0.9.5-cp312-cp312-win32.whl", hash = "sha256:6f2d87720d45a891f606420fcc073796740266f1bca718607569d44b7e0e6639", size = 416143, upload-time = "2026-01-11T19:47:30.894Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/ef3898377abf417a9e30692c1299cb0623f1f42ec6f8d8ba07809ca58eab/whenever-0.9.5-cp312-cp312-win_amd64.whl", hash = "sha256:a5bfb110948bc668728dbb87f8985e6004dedf37ed910a946ddbe31985ada006", size = 440123, upload-time = "2026-01-11T19:47:41.822Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c7/f5626d4cc477116e6ec3191515981a60cdd021adc97046cb422f6bed327c/whenever-0.9.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d7de2cac536fe28f012928b74e0a3ed15dd8f4ac9940cfce35104cca345937f0", size = 467317, upload-time = "2026-01-11T19:47:21.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/81/d59f0e226ef542fc4bc86567d7b9e2bf9016c353b1f83661ee3913a140a7/whenever-0.9.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e00bc8f93fa469c630aad9dfdc538587c28891d6a4dce2f0b08628d5a108a219", size = 438838, upload-time = "2026-01-11T19:47:11.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/dc/090732e6e75f15a6084700d3247db6aa1f885971b637531529c62c4ba1c6/whenever-0.9.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ac83555db44e1fcfc032114f45c09af0ed9d641380672c8deb7f1131a0fd783", size = 453069, upload-time = "2026-01-11T19:45:30.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/b4744370a9491689fc46327a17e3246a9e107b19efa0e24f51d9dcbe6aeb/whenever-0.9.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c486b1db0b833a007e2b8264f265079e57593925131b83ab69514fb9563b8d9", size = 498413, upload-time = "2026-01-11T19:45:49.811Z" },
+    { url = "https://files.pythonhosted.org/packages/62/78/45ef94ef51cb97c514650c2af33cdfc3de3cf967fcf12955c0e3a430a6cf/whenever-0.9.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a57e8f207b5ad9b0c6bcd3efee38d65a70434c1bdcb95cc5d2e2b7a5237c208", size = 487043, upload-time = "2026-01-11T19:46:09.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/23/f45082a60471ee79edc5bf5c09c1d4f55324a2c740fb138a3a691f19d2b6/whenever-0.9.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e1d66a0ece1dabd6952eb7b03a555843bada42bed4683ea71b113f194714144", size = 521879, upload-time = "2026-01-11T19:46:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5c/8d6dc529595b5387f5727cd6c2c5b8615851d95fec5c599a61ef239cc1b3/whenever-0.9.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4056aaff273a579f0294e5397a0d198f52906bbaf7171da0a12ecd8cdf5026c", size = 483388, upload-time = "2026-01-11T19:46:49.746Z" },
+    { url = "https://files.pythonhosted.org/packages/29/52/366c4658286a5986acb76473e9e21457af2bd1b53dc050cee00160106eaa/whenever-0.9.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b0e7c669be2897108895f3283e23fe761782c9c1abb0ce8834e57e09ce5cdfd", size = 521135, upload-time = "2026-01-11T19:46:30.122Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cb/82bbe5ce0879dd38d201214323afad418f1d721111311807c75aaf2e2d16/whenever-0.9.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e0c7a146da12c37d68387c639f957e3624cf7a55a1d534788d5aea748a261e7", size = 636617, upload-time = "2026-01-11T19:45:39.656Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/32/8dcb6facf229b8e2b5c73d0c50adf800593769e34ab5abcd77828451c4ed/whenever-0.9.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70c5f3013d6a1b7c40adbc05bc886e017f2b981739aaceafce47069da5b7e617", size = 769643, upload-time = "2026-01-11T19:45:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/6ab4308550851209982b78692d14a9729bf20b6e814ddedf2658e46a6cd8/whenever-0.9.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a8ce45c7271b85292e9d25e802543942b0249e73976c8614d676f0b561b25420", size = 733170, upload-time = "2026-01-11T19:46:39.457Z" },
+    { url = "https://files.pythonhosted.org/packages/47/38/7ad290229e8df99107d04e21ecef9d09f215428ab3aa06c0e46d51cba860/whenever-0.9.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f1db334becda2d7895bc31373b1e53ff73e3a0ea208e2845b4f946ad9a5e667", size = 696797, upload-time = "2026-01-11T19:47:00.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8e/94c4fba5ef73bb817c557e19bb75665cb5761e4badfb60950bd4d3cc5a01/whenever-0.9.5-cp313-cp313-win32.whl", hash = "sha256:4079eabfa21d1418bcc2c3d605e780cfec0ad8161317e12fa0f1ef87cb08fe7d", size = 416152, upload-time = "2026-01-11T19:47:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b4/17d4bc76ca73c21eb5b7883d10d8bacb7ce7a30a8f36501db2373c63ffb3/whenever-0.9.5-cp313-cp313-win_amd64.whl", hash = "sha256:16497a2b889aeeb0ee80a0d3b9ce14cdb63d7eb7d904e003aae3cd4ac67da1e8", size = 440135, upload-time = "2026-01-11T19:47:42.963Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d3/13db725dfef188bec32e51128e888a869ee97d26d965cfe39edf1321ca8f/whenever-0.9.5-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f222b1d59cdeadc1669657198e572727db8640e0b534e4e1ad0491417ec98379", size = 466415, upload-time = "2026-01-11T19:47:22.7Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/4a9deeb616fbdf8e0c75fc78f13c37270d1d7e7ec776ffdf306262b8c593/whenever-0.9.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6f4ae436a4db888cd5b48a88fb83ae3f70c468a7d0018cc9572e26e99b9f591f", size = 437247, upload-time = "2026-01-11T19:47:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/15/02/21866bddf5f819f1a3a59463f4637755590cb4045d25a50fb6ab60db97a6/whenever-0.9.5-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68b7c201fc49123159b1518147e48791e95a19cba0b3ebb646a446eb7e95148f", size = 451556, upload-time = "2026-01-11T19:45:31.645Z" },
+    { url = "https://files.pythonhosted.org/packages/51/14/2c84db8f23577ddfd6ecd90c8d192d21dfa75aea57cda44eb53048b27e69/whenever-0.9.5-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5d2a8dd9c565eacb199ff704d96fc95e74f6c324639d970cac3b4d80eefbaebb", size = 498034, upload-time = "2026-01-11T19:45:50.926Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/37/cb69a10573382bbfd14954b5386bf5c47290551246d497a9aa733a5b5a8a/whenever-0.9.5-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d965ee9dafe1eb37ec273f7520e26b70d8b1bb075c06b0bb9e434363ca66fd", size = 487381, upload-time = "2026-01-11T19:46:10.752Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c4/fcc0f886322f72c5d83ee669ed1aa253c4e58625e5bf64fede03a69aa7a0/whenever-0.9.5-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035594337920cc9b9eb4531a97037971c109cc60e9a7a53e49e65722a1db7535", size = 520975, upload-time = "2026-01-11T19:46:21.789Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cc/ad7e9c225a97be16b97a20c46802991908a12f9920d83071d669ed7ed79c/whenever-0.9.5-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26c5b04d6fcb0e4ee9f6e62e4400fd99c5f188449314f5863a865be33a653984", size = 481911, upload-time = "2026-01-11T19:46:50.87Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/4fa12c102d6aa3190ce1f34dc9f709776e9c3b1537328c46b6444b9a1638/whenever-0.9.5-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04755e5a2b802451332d2a18bf1c45d74f99cd16e61a0724fe763907f32cf7f8", size = 520068, upload-time = "2026-01-11T19:46:31.175Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/08d7c7e59130e8379240fda96cd68ae60435f6d6b6e356a5900c6856e48f/whenever-0.9.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0f7a37894b9cfc1e68b23f25d19ac38da68454f6bf782eab4cfac58578092daa", size = 635235, upload-time = "2026-01-11T19:45:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6d/49c5566c5560606659dfed8dd49cadfa4d6a14b3f0d7a3d5a46a0c4e5624/whenever-0.9.5-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:55f10416bed357e0d1d1e4bf5e625974fe0a01348117161b4a0d2a69361c0efc", size = 769640, upload-time = "2026-01-11T19:46:00.112Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/09/e05cdc29897b97f3e3c0ffd485bf165f779c6d89bc4c0c0a76592e7c2e8c/whenever-0.9.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:75bfb8c778db727230fa5e7e2e256615be287d00cb1132b93789525e4d1c5dc6", size = 731095, upload-time = "2026-01-11T19:46:40.693Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d1/dcb635c2951ed5a112d340f73bf3cc81d69d1af7c0b1a33d0ca9d3299a26/whenever-0.9.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5bdc5ca9cddc9264d587469d994e046ae9c55cfdb6b9048927fe2922ae8763a1", size = 694782, upload-time = "2026-01-11T19:47:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/56/06/1544751be5e96aeefb59b5fedc1f8f4b0f238197ce21496d5960da20f18c/whenever-0.9.5-cp313-cp313t-win32.whl", hash = "sha256:274b7acfdc1fdfb29ab55299ce0a90cabedd079ff9940e24d05e3de4b04e1638", size = 415984, upload-time = "2026-01-11T19:47:33.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0e/c87cf223816731718e5fef792b1f8c6d124c9fcbec677d4b7c9fcfe8f44f/whenever-0.9.5-cp313-cp313t-win_amd64.whl", hash = "sha256:7c9429fa1249aa39385716644453d9a4de0974b537974988b175d3ba7175a43f", size = 438641, upload-time = "2026-01-11T19:47:44.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e4/5e78fc3b8a2bc84e0f055a89a9f4eabc06bc435463ea112265e1e73592f5/whenever-0.9.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e381120682f6675cccbcba13b4c88b033f31167f820c161936fa99556e455f03", size = 468861, upload-time = "2026-01-11T19:47:24.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a3/bd597dff8c82b2a1568813015ff25f3df2b6817872c8061176f04e3aad0f/whenever-0.9.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:caa7be36a609d765b9ea1c49159c446521b6ac33ff60b67214aa019713e05dda", size = 441322, upload-time = "2026-01-11T19:47:14.184Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3c/fcb3a85cfdc12783c22d44640be538f78bcc3946cc3fb454139cdaebd119/whenever-0.9.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:037fd64e27df6116c3ffe8e96cdb6562051b0eda3f0bc7c35068fe642a913da9", size = 455230, upload-time = "2026-01-11T19:45:32.978Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/17/83c83dddb55f7576f3748b077774d2bd8521bc2220bd2fa6f711ad8f046e/whenever-0.9.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c864363a2ff97c0b661915112140b9229132586d035ee4989cbe914aa3e3df4", size = 499473, upload-time = "2026-01-11T19:45:52.257Z" },
+    { url = "https://files.pythonhosted.org/packages/07/11/406d26cf641ef9e3cdd0f11237a2a49b06f225c5f57257850a2e101c8760/whenever-0.9.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3d2c3f7bc9ceaef7d58fb40f0a4602a1947691eac1bff2623d2f923d4374543", size = 488680, upload-time = "2026-01-11T19:46:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/15/7d85e7f5710fc4dfaec830da0b069791ca6b7108939ab06a0440cfd11f7a/whenever-0.9.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce45c364734e63a459b3b816f1ce159bb4d4f570faa2b0fa504d6d329dd654a3", size = 522715, upload-time = "2026-01-11T19:46:22.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/53/ec6eb7d71624437571ed22c9fbfa7c8532b6868c94138e0775f61c69101c/whenever-0.9.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8fc8e6e500f60299be739e19ffb830b2d9f50da017e14cd832b31f31ee93166", size = 484518, upload-time = "2026-01-11T19:46:51.971Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/220d4a7335d91face9e5c16ec5228ad454ff58cfb3713c291c90d54b3e84/whenever-0.9.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b422bb8651f094f4420749f4c0d72287121480a495c6d247035bd52a72c4586c", size = 522611, upload-time = "2026-01-11T19:46:32.224Z" },
+    { url = "https://files.pythonhosted.org/packages/be/fd/d1b270585f459f469af7c08e03ba2bcfe058449162354bf809e671ccfb1e/whenever-0.9.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:87635742acdd0adbbed62c6ed2ec4a49e25b1e3c7374f13f39d2c5f9229ae24f", size = 638421, upload-time = "2026-01-11T19:45:42.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/7fc33cdb8da7d2b14cd7129f37b48c1aa91644eabc07780333979bdf15f6/whenever-0.9.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1ae39fff83ad73ec563db65707e5bde1e74b350bf4309cfb265d527a6cd222c6", size = 770967, upload-time = "2026-01-11T19:46:01.614Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/a379dcf478136619050cee1ed789a9bdb0a6537fe8c43b23ea832e38c8ce/whenever-0.9.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae5b01eb93c3ad703d7870d9e6566c389b889e97d7efec30c73abf64aa95b47f", size = 735292, upload-time = "2026-01-11T19:46:41.75Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a7/139ac3b81239f1d6275e8eb792c52a48adc6ba303b7e0c9d8ca405a86c76/whenever-0.9.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5e278daa1e650958f9ba7084b1c3c245444acf3e30db9cca5141658347a7c67d", size = 697998, upload-time = "2026-01-11T19:47:02.681Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/37/141041e40f76dd530183c715faae1d8b21e47867fe159b8b88c4960eae2d/whenever-0.9.5-cp314-cp314-win32.whl", hash = "sha256:1b62c62a00bd93e51f71d231aef3178f1c22566b2818c190e755c96fd939b91a", size = 418248, upload-time = "2026-01-11T19:47:34.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/7b/c86657bec1a679042c239a247bc3e6a92f3acc53ec858d13c1e770777f41/whenever-0.9.5-cp314-cp314-win_amd64.whl", hash = "sha256:483c2736ce367dbda01133700b064dfa8b6ed24833fc984e1d767e81aa02a189", size = 442418, upload-time = "2026-01-11T19:47:45.727Z" },
+    { url = "https://files.pythonhosted.org/packages/55/3b/2d37c3438214a1bf6caddddf825d5ff86e6cfcdf91a41fa1175334a2bab0/whenever-0.9.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7644b6c35f9c1fa7b7f6cb03bf5764207374bf3e2049cb49e7578648b0d27dd9", size = 468132, upload-time = "2026-01-11T19:47:25.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0d/284336cf592107ee65c61030f1ca9717214365661d642aadf9fbce38bf8d/whenever-0.9.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:be31d5799b49e593da413cddc73728a51d0e80461262c7a4ed66b95819a69016", size = 438449, upload-time = "2026-01-11T19:47:15.283Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/50/a13b1869b06a8838fab79e31707bf882f836764dcf1260ce170c1084011b/whenever-0.9.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6691e1157026773354c77771cd72db727bbd0ee36121cd139cf16f03cddc1699", size = 452750, upload-time = "2026-01-11T19:45:34.047Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9d/3b9006df1289c78a2e3b8bdd6498430ffee57cb851c938a9da9a7f2ca11d/whenever-0.9.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7e31f4bb592cdd433dde40acef83f968b89178b42169724e0b200a318536c4f", size = 497651, upload-time = "2026-01-11T19:45:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/94/6e66e55649ed8c2e742ca3284e3dd158b0cb3d1272fc7bacc5b0938eba12/whenever-0.9.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f8100609213040dda06e1d078bc43768d5d16dbaabfa75b13c5adb5189056be", size = 488006, upload-time = "2026-01-11T19:46:13.624Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/62/5c0bea83a518f3a76377400bdc29215d2f964be4d1bc8d3886f91824a4cc/whenever-0.9.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38c415a27661f830320c96f3cf6af99ea96b712c9c3a14975ff8c34263d125c6", size = 521517, upload-time = "2026-01-11T19:46:23.874Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0a/e93c2ccfb993d5ac1434913d9a2cea2e79d93affbbec06942c748d04681f/whenever-0.9.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cee6fce59f948dd30c01107d55d40d2c035c6dfd3005c49d535e10175832601c", size = 483401, upload-time = "2026-01-11T19:46:53.531Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/d142ca3b56a1012082d0d2b71f9e9e1b9b42ba266d92294f841cb7acc07e/whenever-0.9.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef181122ffcef41551d5eef483bf12ea48d1115554911a674e404e640ef0fd26", size = 520096, upload-time = "2026-01-11T19:46:33.746Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b9/53a3ebb2c44e7215fa8c6720361a5c78891538f9c934935ffbf508801aae/whenever-0.9.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e4970bc5c37d4fff22e299314bebebb2d1a88133a67a51f87013dad0ac6535fb", size = 637251, upload-time = "2026-01-11T19:45:43.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/17/4f15ae9977972a7b8cd2819c4f03b63884416e4064d6d7366164cd6093f4/whenever-0.9.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:db8043800bd6eba7e681a316cba3734c8d10dad044b4a0dcf5fb0129665902ce", size = 769681, upload-time = "2026-01-11T19:46:03.041Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a5/280dd222b31f478cef551f0d6554ab224e436b7b4ba1456d3cad864de756/whenever-0.9.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:067235cd1be14f709219eae4e6ae639ec19418e7860d1be1e59c5e4bd9cb3542", size = 732487, upload-time = "2026-01-11T19:46:43.395Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/33/d2bed59cfe7cf358e78bfa26bad4414a0a3d99c6aa5e5b76aea448661bae/whenever-0.9.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:81556be508452f5fe7d7e7837718ff91ddb16089a705febe178fa8baabc99236", size = 696906, upload-time = "2026-01-11T19:47:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/b27b182fdf24c9760a91481c6b97d9f536a15f6bc7c33d750eccaa245670/whenever-0.9.5-cp314-cp314t-win32.whl", hash = "sha256:681c9f4d322182df28037a33f0d4eadf7577fcd590130f7a5d23763a86ab5687", size = 417599, upload-time = "2026-01-11T19:47:36.201Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/93/712f65c4fc3c188b0c163cd650cb04a46f993a22d1ad3f66a3e4a42a39f8/whenever-0.9.5-cp314-cp314t-win_amd64.whl", hash = "sha256:37242c895078bb1bfc26bea460f6d92dc5bdfe4a59e95a4f9e01f99b90f0157e", size = 440654, upload-time = "2026-01-11T19:47:46.924Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/1b112af72e5a2b5ac66b5a6a478cc220117224c1481a2b1a35e87222a791/whenever-0.9.5-py3-none-any.whl", hash = "sha256:cc600303e703d57cc42c5db1c81bbc3becb8ef6fde5c46aee5d68c292239fc4b", size = 64873, upload-time = "2026-01-11T19:47:49.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a new omicidx-prefect workspace package mirroring omicidx-dagster's
pipeline (raw extracts → consolidation → postgres load → duckdb build)
on top of Prefect 3. Dagster's built-in partition state is replaced by
JSON marker files under {PUBLISH_ROOT}/_semaphores/{namespace}/{key}.json,
checked before each task and written after the partition output is durably
in place.

Includes:
- per-source flows (sra, geo, biosample, pubmed, ebi_biosample) with
  semaphore-gated extract tasks and a `force` re-run toggle
- consolidation, postgres-load, and duckdb-build flows ported from the
  Dagster assets
- prefect.yaml deployment manifest with cron schedules matching the
  Dagster setup, plus a self-hosted Prefect server + worker docker-compose
- `omicidx-prefect` CLI for inspecting/clearing semaphores and running
  flows locally
- import-time smoke tests + semaphore roundtrip tests

The existing omicidx-dagster package is left untouched for review.