### PR TITLE
feat(prefect): worker-only deploy wired to shared monode prefect-server

### DIFF
--- a/packages/omicidx-prefect/README.md
+++ b/packages/omicidx-prefect/README.md
@@ -109,20 +109,32 @@ uv run omicidx-prefect semaphores list sra/study
 uv run omicidx-prefect semaphores show pubmed pubmed25n0001
 ```
 
-## Self-hosted Prefect
+## Prefect worker
+
+The Prefect server + UI + API is the **shared** instance from monode
+`infrastructure/compose/prefect` (container `prefect-server`, backed by
+pg_main, reached over the tailnet). This package ships a **worker only**:
+`docker-compose.yml` builds the omicidx worker image and joins the shared
+`pg_main_stack_default` network, which is how it reaches both
+`prefect-server:4200` (the API) and `pg_main:5432` (the DuckLake catalog
++ serving Postgres).
 
 ```bash
 cd packages/omicidx-prefect
 
-# .env supplies the same vars as the dagster package
+# .env supplies S3_*, PUBLISH_ROOT, POSTGRES_URI, DUCKLAKE_URI, DUCKLAKE_DATA_PATH
 cp .env.example .env  # (create one if you haven't)
 
+# build + start the worker (shared prefect-server must already be running)
 docker compose up -d --build
-# UI at http://localhost:4200
 
+# register/refresh deployments (schedules) on the shared server
 docker compose exec worker prefect deploy --all
 docker compose exec worker prefect deployment ls
 ```
+
+The pipeline is `raw-extract → ducklake-load → postgres-load →
+duckdb-build`; schedules live in `prefect.yaml`.
 
 ## Mapping from Dagster
 

--- a/packages/omicidx-prefect/README.md
+++ b/packages/omicidx-prefect/README.md
@@ -73,7 +73,7 @@ packages/omicidx-prefect/
 ├── pyproject.toml
 ├── prefect.yaml             # deployments (schedules)
 ├── Dockerfile               # worker image
-├── docker-compose.yml       # prefect server + db + worker
+├── docker-compose.yml       # worker (joins shared monode prefect-server)
 ├── src/omicidx/prefect/
 │   ├── config.py            # Settings + storage / duckdb / postgres helpers
 │   ├── semaphore.py         # SemaphoreStore

--- a/packages/omicidx-prefect/docker-compose.yml
+++ b/packages/omicidx-prefect/docker-compose.yml
@@ -1,71 +1,48 @@
-# Self-hosted Prefect server + worker for omicidx ETL.
+# omicidx ETL Prefect worker.
 #
-# Bring up:
+# This is WORKER-ONLY. The Prefect server + UI + API is the shared
+# instance from monode infrastructure/compose/prefect (container
+# `prefect-server`, backed by pg_main). We do NOT run a second server.
+#
+# The worker joins the shared `pg_main_stack_default` network, which is
+# how it reaches both:
+#   - prefect-server:4200   (the orchestration API)
+#   - pg_main:5432          (the DuckLake catalog + serving Postgres)
+#
+# Bring up (after the shared prefect-server is running):
 #   docker compose up -d --build
 #
-# Apply deployments (one-time, after the server is healthy):
+# Register/refresh deployments (one-time, from any tailnet client or the
+# worker itself):
 #   docker compose exec worker prefect deploy --all
 #
-# UI is exposed at http://localhost:4200 (PREFECT_API_URL).
+# Secrets/config come from packages/omicidx-prefect/.env (gitignored).
 
 services:
-  prefect-db:
-    image: postgres:16
-    container_name: omicidx-prefect-db
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: prefect
-      POSTGRES_PASSWORD: ${PREFECT_DB_PASSWORD:-prefect}
-      POSTGRES_DB: prefect
-    volumes:
-      - prefect-db-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U prefect"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  prefect-server:
-    image: prefecthq/prefect:3-latest
-    container_name: omicidx-prefect-server
-    restart: unless-stopped
-    depends_on:
-      prefect-db:
-        condition: service_healthy
-    ports:
-      - "4200:4200"
-    environment:
-      PREFECT_SERVER_API_HOST: "0.0.0.0"
-      PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:${PREFECT_DB_PASSWORD:-prefect}@prefect-db:5432/prefect
-      PREFECT_UI_API_URL: http://localhost:4200/api
-    command: ["prefect", "server", "start", "--host", "0.0.0.0"]
-    healthcheck:
-      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', 4200), timeout=5)"]
-      interval: 30s
-      timeout: 10s
-      start_period: 30s
-      retries: 5
-
   worker:
     build:
       context: ../..
       dockerfile: packages/omicidx-prefect/Dockerfile
     container_name: omicidx-prefect-worker
     restart: unless-stopped
-    depends_on:
-      prefect-server:
-        condition: service_healthy
+    networks:
+      - pg_main_stack_default
     environment:
-      PREFECT_API_URL: http://prefect-server:4200/api
-      # R2/S3 storage
+      # Talk to the shared monode prefect-server over the shared network.
+      PREFECT_API_URL: ${PREFECT_API_URL:-http://prefect-server:4200/api}
+      # R2/S3 storage (raw inputs + published artifacts).
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
       S3_REGION: ${S3_REGION:-auto}
       S3_URL_STYLE: ${S3_URL_STYLE:-path}
       PUBLISH_ROOT: ${PUBLISH_ROOT:-s3://omicidx}
-      # API-serving Postgres
+      # API-serving Postgres (postgres-load target).
       POSTGRES_URI: ${POSTGRES_URI:-postgresql://omicidx@pg_main:5432/omicidx}
+      # DuckLake catalog (ducklake-load). Host pg_main resolves on the
+      # shared network; the catalog's stored data_path governs I/O.
+      DUCKLAKE_URI: ${DUCKLAKE_URI}
+      DUCKLAKE_DATA_PATH: ${DUCKLAKE_DATA_PATH}
     command:
       - prefect
       - worker
@@ -75,5 +52,6 @@ services:
       - --type
       - process
 
-volumes:
-  prefect-db-data:
+networks:
+  pg_main_stack_default:
+    external: true

--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -1,13 +1,16 @@
 # Prefect deployment manifest for omicidx ETL.
 #
-# Apply with:
-#   prefect deploy --all
+# Apply with (against the shared monode prefect-server):
+#   docker compose exec worker prefect deploy --all
 #
-# Schedules mirror the Dagster setup:
-#   - daily-pipeline:           02:00 UTC (full extract → consolidate → load → build)
-#   - hourly-pubmed:            poll FTP for new PubMed files
-#   - hourly-sra-accessions:    check SRA_Accessions.tab ETag, reload if changed
-#   - geo-monthly-rerun:        re-extract current month at 06:00 UTC daily
+# Pipeline shape (post-DuckLake-cutover):
+#   raw-extract -> ducklake-load -> postgres-load -> duckdb-build
+#
+# Schedules:
+#   - daily-pipeline:       02:00 UTC (full extract -> lake -> postgres -> build)
+#   - ducklake-maintenance: 04:00 UTC Sunday (expire snapshots + cleanup + compact)
+#   - pubmed-extract:       hourly (poll FTP for new PubMed files)
+#   - geo-extract:          06:00 UTC daily (re-fire current month)
 
 name: omicidx-prefect
 prefect-version: 3.0.0
@@ -23,8 +26,9 @@ pull:
 deployments:
   - name: daily-pipeline
     description: |
-      Full daily ETL: raw extracts (semaphore-gated), consolidation,
-      postgres reload, duckdb build + upload.
+      Full daily ETL: raw extracts (semaphore-gated) -> ducklake-load
+      (MERGE raw into lake.omicidx.*) -> postgres reload (reads the lake)
+      -> duckdb build + upload.
     entrypoint: src/omicidx/prefect/flows/main.py:daily_pipeline_flow
     work_pool:
       name: default
@@ -36,6 +40,29 @@ deployments:
     parameters:
       force: false
 
+  - name: ducklake-load
+    description: |
+      MERGE every entity's raw data into the DuckLake catalog
+      (lake.omicidx.*). Standalone entry point; also runs inside
+      daily-pipeline. Idempotent (hash-gated).
+    entrypoint: src/omicidx/prefect/flows/ducklake_load.py:ducklake_load_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+
+  - name: ducklake-maintenance
+    description: |
+      Catalog maintenance: expire old snapshots, delete unreferenced
+      data files, and compact adjacent files. Weekly.
+    entrypoint: src/omicidx/prefect/flows/ducklake_load.py:ducklake_maintenance_flow
+    work_pool:
+      name: default
+      work_queue_name: default
+    schedules:
+      - cron: "0 4 * * 0"
+        timezone: UTC
+        active: true
+
   - name: pubmed-extract
     description: Poll PubMed FTP for new files, extract any missing partitions.
     entrypoint: src/omicidx/prefect/flows/pubmed.py:pubmed_extract_flow
@@ -45,18 +72,6 @@ deployments:
     schedules:
       - interval: 3600
         active: true
-
-  - name: sra-accessions-etag
-    description: |
-      Re-ingest SRA_Accessions.tab when its ETag changes. Runs the
-      consolidation flow's etag-gated task in isolation.
-    entrypoint: src/omicidx/prefect/flows/consolidate.py:consolidate_flow
-    work_pool:
-      name: default
-      work_queue_name: default
-    schedules:
-      - interval: 3600
-        active: false  # daily-pipeline covers this; enable for tighter polling
 
   - name: geo-extract
     description: |
@@ -74,15 +89,8 @@ deployments:
       rerun_current_month: true
       force: false
 
-  - name: consolidate
-    description: Per-entity raw → parquet consolidation.
-    entrypoint: src/omicidx/prefect/flows/consolidate.py:consolidate_flow
-    work_pool:
-      name: default
-      work_queue_name: default
-
   - name: postgres-load
-    description: Reload every API-serving table from its consolidated parquet.
+    description: Reload every API-serving table from its DuckLake source table.
     entrypoint: src/omicidx/prefect/flows/postgres.py:postgres_load_flow
     work_pool:
       name: default


### PR DESCRIPTION
## What

Wire the omicidx-prefect **worker** to the existing shared monode `prefect-server` instead of standing up a second Prefect server. This is the path to a real scheduled Prefect deployment for the DuckLake pipeline.

### docker-compose.yml → worker-only
- Drop the bundled `prefect-server` + `prefect-db` (monode infra already runs `prefect-server`, backed by pg_main).
- Worker joins the shared external `pg_main_stack_default` network → reaches `prefect-server:4200` (API) and `pg_main:5432` (DuckLake catalog + serving Postgres) over one network.
- **Add the previously-missing `DUCKLAKE_URI` / `DUCKLAKE_DATA_PATH` env** — without them `ducklake-load` raised `RuntimeError: DUCKLAKE_URI is not set` in-container.

### prefect.yaml → post-cutover deployment set
- Add `ducklake-load` + `ducklake-maintenance` (weekly cron) deployments.
- Drop stale `consolidate` / `sra-accessions-etag` deployments (consolidate is no longer in the pipeline path).
- Pipeline: `raw-extract → ducklake-load → postgres-load → duckdb-build`.

### README
- Document worker-only model + shared server; correct the layout note.

## Verification
- `docker compose config` validates.
- All 7 deployment entrypoints resolve to real flow objects.
- Nothing started — operator brings up with `docker compose up -d --build` then `docker compose exec worker prefect deploy --all`.

## Not in scope
- Running compose / registering deployments on the host.
- ADR-0004 public snapshot publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)