### PR TITLE
feat(prefect): parquet-export reverse-ETL (lake → public Parquet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ omicidx/                        # workspace root (no package of its own)
     │   └── src/omicidx/etl/
     ├── omicidx-dagster/        # Dagster code location for ETL orchestration + postgres loads
     │   └── src/omicidx/dagster/
+    ├── omicidx-prefect/        # Prefect 3 reimplementation of the ETL pipeline (DuckLake)
+    │   └── src/omicidx/prefect/
     └── omicidx-api/            # Read-only FastAPI REST API backed by PostgreSQL
         └── src/omicidx/api/
 ```
@@ -87,6 +89,28 @@ SQL files in `packages/omicidx-etl/src/omicidx/etl/sql/` define a two-stage Duck
 
 - `010_raw_to_parquet.sql` — raw data consolidation (run via `oidx sql run`)
 - `020_`–`050_*.sql` — view definitions (`src_*`, `stg_*`, `geometadb.*`, `sradb.*`) built by `oidx build-db`
+
+### omicidx-prefect
+
+Prefect 3 reimplementation of the omicidx-dagster pipeline on the DuckLake
+substrate. Partition state lives in **semaphore JSON files** in the storage
+bucket (not Dagster's event log). Pipeline:
+
+```
+raw-extract → ducklake-load → parquet-export → postgres-load → duckdb-build
+```
+
+| Stage | Module | What it does |
+|---|---|---|
+| `raw-extract` | `flows/{sra,geo,biosample,ebi_biosample,pubmed}.py` | NCBI/EBI → raw Parquet/NDJSON on R2 (`PUBLISH_ROOT`), semaphore-gated |
+| `ducklake-load` | `flows/ducklake*.py` | MERGE raw → `lake.omicidx.*` (hash-gated, copy-on-write; SRA high-water-mark incremental) |
+| `parquet-export` | `flows/parquet_export.py` | Reverse-ETL: COPY lake tables → public Parquet `r2://data-omicidx/latest/*.parquet` (ADR-0004) |
+| `postgres-load` | `flows/postgres.py` | Reload API-serving Postgres tables from the lake (A/B-slot swap) |
+| `duckdb-build` | `flows/sql.py` + `sql/020–050` | Build `omicidx.duckdb` from the public Parquet via view SQL |
+
+- Config: `config.py` (`Settings` + `get_ducklake_connection`, `get_public_parquet_path`, etc.). Key env: `PUBLISH_ROOT`, `DUCKLAKE_URI`, `DUCKLAKE_DATA_PATH`, `PUBLIC_PARQUET_ROOT`, `PUBLIC_PARQUET_HTTPS_BASE`, `POSTGRES_URI`.
+- Catalog topology + MERGE/maintenance conventions: `DUCKLAKE.md`. Public-serving contract: `docs/adrs/0004`.
+- Operator CLI `omicidx-prefect` (`cli.py`); deployments in `prefect.yaml`; worker-only `docker-compose.yml` joins the shared monode `prefect-server`.
 
 ### omicidx-api
 

--- a/packages/omicidx-prefect/README.md
+++ b/packages/omicidx-prefect/README.md
@@ -133,8 +133,9 @@ docker compose exec worker prefect deploy --all
 docker compose exec worker prefect deployment ls
 ```
 
-The pipeline is `raw-extract → ducklake-load → postgres-load →
-duckdb-build`; schedules live in `prefect.yaml`.
+The pipeline is `raw-extract → ducklake-load → parquet-export →
+postgres-load → duckdb-build`; schedules live in `prefect.yaml`.
+`parquet-export` is the reverse-ETL (lake → public Parquet, ADR-0004).
 
 ## Mapping from Dagster
 
@@ -165,6 +166,10 @@ S3_ENDPOINT=https://....r2.cloudflarestorage.com
 S3_REGION=auto
 S3_URL_STYLE=path
 POSTGRES_URI=postgresql://omicidx@host:5432/omicidx
+
+# Public Parquet export (reverse-ETL; ADR-0004)
+PUBLIC_PARQUET_ROOT=r2://data-omicidx                       # dedicated public bucket
+PUBLIC_PARQUET_HTTPS_BASE=https://data-omicidx.cancerdatasci.org  # base for views.sql URLs
 ```
 
 ## Tests

--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -4,7 +4,7 @@
 #   docker compose exec worker prefect deploy --all
 #
 # Pipeline shape (post-DuckLake-cutover):
-#   raw-extract -> ducklake-load -> postgres-load -> duckdb-build
+#   raw-extract -> ducklake-load -> parquet-export -> postgres-load -> duckdb-build
 #
 # Schedules:
 #   - daily-pipeline:       02:00 UTC (full extract -> lake -> postgres -> build)
@@ -88,6 +88,16 @@ deployments:
     parameters:
       rerun_current_month: true
       force: false
+
+  - name: parquet-export
+    description: |
+      Reverse-ETL: COPY every core lake table out to the public Parquet
+      bucket (latest/*.parquet, ADR-0004). Source for duckdb-build + the
+      co-published views.sql. Standalone; also runs inside daily-pipeline.
+    entrypoint: src/omicidx/prefect/flows/parquet_export.py:parquet_export_flow
+    work_pool:
+      name: default
+      work_queue_name: default
 
   - name: postgres-load
     description: Reload every API-serving table from its DuckLake source table.

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -139,6 +139,15 @@ def run_ducklake_maintenance() -> None:
     ducklake_maintenance_flow()
 
 
+@run.command("parquet-export")
+@click.option("--lake-schema", default=None, help="Override source lake schema.")
+def run_parquet_export(lake_schema: str | None) -> None:
+    from omicidx.prefect.flows.ducklake import LAKE_SCHEMA
+    from omicidx.prefect.flows.parquet_export import parquet_export_flow
+
+    parquet_export_flow(lake_schema=lake_schema or LAKE_SCHEMA)
+
+
 @run.command("postgres")
 def run_postgres() -> None:
     from omicidx.prefect.flows.postgres import postgres_load_flow

--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
     postgres_uri: str | None = None
     ducklake_uri: str | None = None
     ducklake_data_path: str | None = None
+    # Public Parquet export (reverse-ETL target; ADR-0004). The dedicated
+    # public bucket, separate from PUBLISH_ROOT (raw) and cdsci-lake (lake).
+    public_parquet_root: str | None = None  # e.g. r2://data-omicidx
+    public_parquet_https_base: str | None = None  # e.g. https://data-omicidx.cancerdatasci.org
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -73,6 +77,22 @@ def get_upath(*parts: str) -> UPath:
 def get_duckdb_path(*parts: str) -> str:
     """Build an r2:// path for use in DuckDB SQL with the r2 secret."""
     upath = UPath(settings().publish_root, *parts)
+    return str(upath).replace("s3://", "r2://", 1)
+
+
+def get_public_parquet_path(*parts: str) -> str:
+    """Build an r2:// path under the public parquet root for DuckDB COPY.
+
+    The R2 secret created in `get_duckdb_connection()` is account-scoped
+    (no SCOPE), so a COPY to this bucket reuses it — no extra credentials.
+    """
+    root = settings().public_parquet_root
+    if not root:
+        raise RuntimeError("PUBLIC_PARQUET_ROOT is not set")
+    # UPath has no r2 filesystem; build with s3:// then emit r2:// for DuckDB
+    # (same trick as get_duckdb_path). Accepts an s3:// or r2:// root.
+    root_s3 = root.replace("r2://", "s3://", 1)
+    upath = UPath(root_s3, *parts)
     return str(upath).replace("s3://", "r2://", 1)
 
 

--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -39,7 +39,9 @@ class Settings(BaseSettings):
     # Public Parquet export (reverse-ETL target; ADR-0004). The dedicated
     # public bucket, separate from PUBLISH_ROOT (raw) and cdsci-lake (lake).
     public_parquet_root: str | None = None  # e.g. r2://data-omicidx
-    public_parquet_https_base: str | None = None  # e.g. https://data-omicidx.cancerdatasci.org
+    public_parquet_https_base: str | None = (
+        None  # e.g. https://data-omicidx.cancerdatasci.org
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_load.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_load.py
@@ -6,8 +6,8 @@ daily pipeline (wired in P3). Shared helpers live in `ducklake.py`; each
 entity's source projection + task lives in its own `ducklake_<entity>.py`
 module so they can evolve independently.
 
-Targets `LAKE_SCHEMA` (`omicidx_dev` during the transition; promote to
-`omicidx` at cutover).
+Targets `LAKE_SCHEMA` (`omicidx`; pass an explicit `lake_schema` to target
+a dev schema for validation).
 """
 
 from omicidx.prefect.flows.ducklake import (

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -1,14 +1,17 @@
 """Top-level pipeline flows.
 
 `daily_pipeline_flow` runs the raw extracts, then the DuckLake load
-(MERGE raw → lake.omicidx.*), then the postgres loads (which read from
-the lake), then the duckdb build. Each step is a subflow, so failure of
-one stage halts the rest with full visibility.
+(MERGE raw → lake.omicidx.*), then the parquet export (lake → public
+Parquet, the reverse-ETL), then the postgres loads (which read the lake
+directly), then the duckdb build (which reads the exported Parquet). Each
+step is a subflow, so failure of one stage halts the rest with full
+visibility.
 
-The old `consolidate` step (raw → consolidated parquet) is replaced by
-`ducklake-load`. `consolidate.py` is retained for now only because the
-public duckdb-build SQL views still read published parquet; that build
-will be repointed to the lake separately.
+The old `consolidate` step (raw → consolidated parquet) is fully replaced
+by `ducklake-load` + `parquet-export`: the lake is the single source of
+truth, and `parquet-export` COPYs the merged tables out for public serving
+and the duckdb build. `consolidate.py` is dead once `parquet-export` is
+verified in prod.
 """
 
 from omicidx.prefect.flows.biosample import (
@@ -18,6 +21,7 @@ from omicidx.prefect.flows.biosample import (
 from omicidx.prefect.flows.ducklake_load import ducklake_load_flow
 from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
 from omicidx.prefect.flows.geo import geo_extract_flow, geo_rna_seq_counts_flow
+from omicidx.prefect.flows.parquet_export import parquet_export_flow
 from omicidx.prefect.flows.postgres import postgres_load_flow
 from omicidx.prefect.flows.pubmed import pubmed_extract_flow
 from omicidx.prefect.flows.sql import omicidx_duckdb_flow
@@ -40,9 +44,10 @@ def raw_extract_flow(force: bool = False) -> None:
 
 @flow(name="daily-pipeline")
 def daily_pipeline_flow(force: bool = False) -> None:
-    """Daily end-to-end pipeline: extract → ducklake-load → postgres → build."""
+    """Daily pipeline: extract → ducklake-load → parquet-export → postgres → build."""
     raw_extract_flow(force=force)
     ducklake_load_flow()
+    parquet_export_flow()
     postgres_load_flow()
     omicidx_duckdb_flow()
 

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
@@ -1,0 +1,73 @@
+"""Parquet export flow: lake.<schema>.* → public Parquet (reverse-ETL).
+
+The public-serving half of ADR-0004. Each core lake table is COPY'd out of
+the DuckLake catalog to a flat Parquet file under the dedicated public bucket
+(`PUBLIC_PARQUET_ROOT`, e.g. `r2://data-omicidx`) at `latest/<file>.parquet`.
+
+This replaces the old `consolidate.py` path (raw → consolidated parquet) as
+the source for `omicidx-duckdb-build` and the co-published `views.sql`: the
+lake is now the single source of truth, and the export is a straight COPY of
+the merged tables (no re-aggregation from raw).
+
+Rolling-`latest/` only — overwritten each run. Versioned `vN.N/` snapshots
+(ADR-0004) are a later follow-up that freezes `latest/` into an immutable
+prefix.
+
+The R2 secret built by `get_ducklake_connection()` is account-scoped, so the
+COPY into a *different* bucket than the lake's `cdsci-lake` reuses it with no
+extra credentials.
+"""
+
+from omicidx.prefect.config import get_ducklake_connection, get_public_parquet_path
+from omicidx.prefect.flows.ducklake import LAKE_SCHEMA
+
+from prefect import flow, get_run_logger, task
+
+# (lake table, public parquet filename). Names differ: lake tables are
+# singular; the public files (and the 020 src_* views) use the plural form.
+# Authoritative against sql/020_base_parquet_views.sql + the ducklake_* loaders.
+EXPORTS: list[tuple[str, str]] = [
+    ("bioproject", "bioprojects.parquet"),
+    ("biosample", "biosamples.parquet"),
+    ("geo_series", "geo_series.parquet"),
+    ("geo_sample", "geo_samples.parquet"),
+    ("geo_platform", "geo_platforms.parquet"),
+    ("sra_study", "sra_studies.parquet"),
+    ("sra_sample", "sra_samples.parquet"),
+    ("sra_experiment", "sra_experiments.parquet"),
+    ("sra_run", "sra_runs.parquet"),
+    ("pubmed_article", "pubmed_articles.parquet"),
+]
+
+
+@task(retries=1, retry_delay_seconds=60)
+def export_table(lake_table: str, filename: str, lake_schema: str = LAKE_SCHEMA) -> dict:
+    """COPY lake.<schema>.<lake_table> → <public root>/latest/<filename>."""
+    log = get_run_logger()
+    output = get_public_parquet_path("latest", filename)
+    with get_ducklake_connection() as con:
+        log.info(f"Exporting lake.{lake_schema}.{lake_table} → {output}")
+        con.execute(
+            f"COPY (SELECT * FROM lake.{lake_schema}.{lake_table}) "
+            f"TO '{output}' (FORMAT PARQUET, COMPRESSION ZSTD)"
+        )
+        row_count = con.execute(
+            f"SELECT count(*) FROM read_parquet('{output}')"
+        ).fetchone()[0]
+    log.info(f"Wrote {row_count:,} rows to {output}")
+    return {"table": f"{lake_schema}.{lake_table}", "file": filename, "row_count": row_count}
+
+
+@flow(name="parquet-export")
+def parquet_export_flow(lake_schema: str = LAKE_SCHEMA) -> None:
+    """Export every core lake table to the public Parquet bucket (latest/).
+
+    Sits between `ducklake-load` and `duckdb-build` in the daily pipeline:
+    the build and the public `views.sql` read these files.
+    """
+    for lake_table, filename in EXPORTS:
+        export_table(lake_table, filename, lake_schema=lake_schema)
+
+
+if __name__ == "__main__":
+    parquet_export_flow()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
@@ -41,7 +41,9 @@ EXPORTS: list[tuple[str, str]] = [
 
 
 @task(retries=1, retry_delay_seconds=60)
-def export_table(lake_table: str, filename: str, lake_schema: str = LAKE_SCHEMA) -> dict:
+def export_table(
+    lake_table: str, filename: str, lake_schema: str = LAKE_SCHEMA
+) -> dict:
     """COPY lake.<schema>.<lake_table> → <public root>/latest/<filename>."""
     log = get_run_logger()
     output = get_public_parquet_path("latest", filename)
@@ -55,7 +57,11 @@ def export_table(lake_table: str, filename: str, lake_schema: str = LAKE_SCHEMA)
             f"SELECT count(*) FROM read_parquet('{output}')"
         ).fetchone()[0]
     log.info(f"Wrote {row_count:,} rows to {output}")
-    return {"table": f"{lake_schema}.{lake_table}", "file": filename, "row_count": row_count}
+    return {
+        "table": f"{lake_schema}.{lake_table}",
+        "file": filename,
+        "row_count": row_count,
+    }
 
 
 @flow(name="parquet-export")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
@@ -5,9 +5,8 @@ One task per entity. Each task loads a DuckLake table
 pattern) and atomically swaps a view to point at the new one. The API
 reads through the view, so reads never block during reload.
 
-Sources track the ducklake-load schema (LAKE_SCHEMA = omicidx_dev during
-the transition; flips to omicidx at cutover). `consolidate` remains as a
-fallback until this path is validated end-to-end.
+Sources track the ducklake-load schema (LAKE_SCHEMA = omicidx). Postgres
+reads the lake tables directly, independent of the public parquet export.
 """
 
 import asyncio

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sql.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sql.py
@@ -1,7 +1,8 @@
 """DuckDB build flow.
 
-Builds the omicidx.duckdb file from consolidated parquet views
-(020-050 SQL) and uploads it to R2/S3.
+Builds the omicidx.duckdb file from the public Parquet snapshot produced by
+`parquet-export` (020-050 SQL views over `latest/*.parquet`) and uploads it
+to R2/S3. The view base URL is templated from PUBLIC_PARQUET_HTTPS_BASE.
 """
 
 import json
@@ -11,12 +12,16 @@ from pathlib import Path
 
 import duckdb
 import sqlglot
-from omicidx.prefect.config import get_duckdb_connection, get_upath
+from omicidx.prefect.config import get_duckdb_connection, get_upath, settings
 
 from prefect import flow, get_run_logger, task
 
 SQL_DIR = Path(__file__).parent.parent / "sql"
 DB_FILE = "omicidx.duckdb"
+# Placeholder in the view SQL for the public Parquet HTTPS base, so the
+# published views.sql carries a concrete URL that agrees with the export
+# write path (PUBLIC_PARQUET_ROOT). See sql/020_base_parquet_views.sql.
+PUBLIC_PARQUET_BASE_PLACEHOLDER = "{{PUBLIC_PARQUET_BASE}}"
 
 
 def _list_sql_files() -> list[str]:
@@ -28,7 +33,16 @@ def _get_sql(name: str) -> str:
     if not path.exists():
         available = ", ".join(_list_sql_files())
         raise FileNotFoundError(f"SQL file '{name}' not found. Available: {available}")
-    return path.read_text()
+    sql = path.read_text()
+    if PUBLIC_PARQUET_BASE_PLACEHOLDER in sql:
+        base = settings().public_parquet_https_base
+        if not base:
+            raise RuntimeError(
+                "PUBLIC_PARQUET_HTTPS_BASE is not set but "
+                f"{name} references {PUBLIC_PARQUET_BASE_PLACEHOLDER}"
+            )
+        sql = sql.replace(PUBLIC_PARQUET_BASE_PLACEHOLDER, base.rstrip("/"))
+    return sql
 
 
 def _run_sql_file(name: str, con: duckdb.DuckDBPyConnection) -> None:

--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
@@ -1,13 +1,21 @@
+-- Base views over the public Parquet snapshot (reverse-ETL output of
+-- `parquet-export`). {{PUBLIC_PARQUET_BASE}} is substituted at build time
+-- from PUBLIC_PARQUET_HTTPS_BASE (config.py); the published views.sql ships
+-- with the concrete URL so external DuckDB users can `.read` it directly.
+
 create or replace view src_geo_series as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/geo_series.parquet')
 );
 
 create or replace view src_geo_samples as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_samples.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/geo_samples.parquet')
 );
 
+-- TODO(derived): geo_series_with_rnaseq_counts is not yet exported by
+-- parquet-export (orphaned ducklake loader). Stays on the old consolidated
+-- URL until the derived loaders are wired. See plan follow-ups.
 create or replace view src_geo_series_with_rnaseq_counts as (
     select accession
     from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series_with_rnaseq_counts.parquet')
@@ -15,7 +23,7 @@ create or replace view src_geo_series_with_rnaseq_counts as (
 
 create or replace view src_geo_platforms as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_platforms.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/geo_platforms.parquet')
 );
 
 -----
@@ -26,24 +34,27 @@ create or replace view src_geo_platforms as (
 
 create or replace view src_sra_studies as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_studies.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/sra_studies.parquet')
 );
 
 create or replace view src_sra_samples as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_samples.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/sra_samples.parquet')
 );
 
 create or replace view src_sra_experiments as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_experiments.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/sra_experiments.parquet')
 );
 
 create or replace view src_sra_runs as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_runs.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/sra_runs.parquet')
 );
 
+-- TODO(derived): sra_accessions is not yet exported by parquet-export
+-- (orphaned ducklake loader). Stays on the old consolidated URL until the
+-- derived loaders are wired. See plan follow-ups.
 create or replace view src_sra_accessions as (
     select *
     from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet')
@@ -57,12 +68,12 @@ create or replace view src_sra_accessions as (
 
 create or replace view src_biosamples as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/biosample/parquet/biosamples.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/biosamples.parquet')
 );
 
 create or replace view src_bioprojects as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/bioproject/parquet/bioprojects.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/bioprojects.parquet')
 );
 
 -----
@@ -73,8 +84,7 @@ create or replace view src_bioprojects as (
 
 create or replace view src_pubmed_articles as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/pubmed/parquet/pubmed_articles.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/latest/pubmed_articles.parquet')
 );
 
 -- End of base parquet views
-


### PR DESCRIPTION
## Context

The `omicidx-prefect` daily pipeline tail was broken. `duckdb-build` (`sql.py`) and the public views (`sql/020`) still `read_parquet(...)` the **old consolidated parquet** made by `consolidate.py` — but **#107 dropped `consolidate` from the pipeline**, so the build read parquet nothing refreshed. Nothing exported the live lake back to parquet.

This adds the missing **reverse-ETL** and realizes the public-serving half of **ADR-0004** (rolling `latest/`; versioned `vN.N/` snapshots are a later follow-up).

**Decisions:** rolling `latest/` only · new dedicated `data-omicidx` bucket · defer the 3 derived tables.

## Pipeline

`raw-extract → ducklake-load → `**`parquet-export`**` → postgres-load → duckdb-build`

`postgres-load` reads the lake directly (unaffected); `duckdb-build` now reads the exported Parquet.

## Changes

| Area | File | Change |
|---|---|---|
| Reverse-ETL flow | `flows/parquet_export.py` (new) | `parquet-export`: COPY 10 core lake tables → `r2://data-omicidx/latest/*.parquet` (ZSTD). Static export map; reuses account-scoped R2 secret (no new creds) |
| Config | `config.py` | `PUBLIC_PARQUET_ROOT` + `PUBLIC_PARQUET_HTTPS_BASE`; `get_public_parquet_path()` (normalizes `r2://`/`s3://` for UPath) |
| Pipeline | `flows/main.py` | Insert `parquet_export_flow()` before postgres |
| Views | `sql/020_base_parquet_views.sql` + `flows/sql.py` | 8 core `src_*` views → `{{PUBLIC_PARQUET_BASE}}/latest/*`; placeholder substituted at build time from `PUBLIC_PARQUET_HTTPS_BASE`. 2 derived views kept on old URL w/ `TODO(derived)` |
| Plumbing | `cli.py`, `prefect.yaml` | `run parquet-export` command + standalone deployment |
| Docs | `README.md`, `CLAUDE.md` | env + pipeline; register package. Stale `omicidx_dev` docstrings fixed |

## Lake → public name map

| lake table | public file | · | lake table | public file |
|---|---|---|---|---|
| `bioproject` | `bioprojects.parquet` | | `sra_study` | `sra_studies.parquet` |
| `biosample` | `biosamples.parquet` | | `sra_sample` | `sra_samples.parquet` |
| `geo_series` | `geo_series.parquet` | | `sra_experiment` | `sra_experiments.parquet` |
| `geo_sample` | `geo_samples.parquet` | | `sra_run` | `sra_runs.parquet` |
| `geo_platform` | `geo_platforms.parquet` | | `pubmed_article` | `pubmed_articles.parquet` |

## Verification

| Check | Status |
|---|---|
| `pytest packages/omicidx-prefect/tests/` | ✅ 4 passed |
| Module imports + flow names | ✅ |
| CLI registers `parquet-export` | ✅ |
| Placeholder substitution → concrete URL; derived views left old | ✅ |
| Path helper resolves `r2://` + `s3://` roots | ✅ |
| **Live COPY against real lake** | ⏳ needs `data-omicidx` bucket + public HTTPS mapping + in-container run |

## Deferred (separate PRs)

- Remove `consolidate.py` after prod-verify (still the live source until export runs).
- Wire `ebi_biosample` + 3 derived loaders; move the 2 `TODO(derived)` views to `latest/`.
- ADR-0004 versioned `vN.N/` snapshot-cut flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)