### PR TITLE
fix(prefect): union_by_name in ebi-biosample consolidate read

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
@@ -177,6 +177,7 @@ def consolidate_ebi_biosample_parquet() -> dict:
             FROM read_ndjson_auto(
                 '{input_glob}',
                 maximum_object_size = 1000000000,
+                union_by_name = true,
                 ignore_errors = false
             )
         ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION ZSTD)


### PR DESCRIPTION
## Problem

15 consecutive `daily-pipeline` failures, all:

```
InvalidInputException: JSON transform error in file
"r2://omicidx-test/ebi_biosample/raw/biosamples-2021-06-10.ndjson.gz",
in line 1: Object {...} has unknown key "webinSubmissionAccountId"
```

Failing stage is the **`ebi-biosample-extract`** subflow's `consolidate_ebi_biosample_parquet`, not ducklake-load.

## Cause

`read_ndjson_auto` over the 1330-file `biosamples-*.ndjson.gz` glob ran **without `union_by_name=true`**. DuckDB inferred the top-level schema from a sampled subset of files, then `SELECT *` transform failed on any later file carrying a sparse top-level key (`webinSubmissionAccountId`) the inferred schema missed. The failing file changed run-to-run (06-10, 08-25, 08-21) as sample/file ordering varied — classic union_by_name symptom; DuckDB's own error hint says to set it.

## Fix

Add `union_by_name = true`, mirroring the sibling `ducklake_ebi_biosample.py` loader that reads the same glob and succeeds.

## Verification

Reproduced against live R2 (DuckDB 1.5.3, all 1330 files):
- bare `count(*)`: OK (count skips JSON transform — masks the bug)
- full typed projection **with `union_by_name=true`: OK, 51,377,606 rows**

## Deploy note

Worker pulls code from `/opt/prefect/omicidx` via `set_working_directory` (no git-pull step). That path must be updated on the worker before the next 02:00 UTC run picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)