### PR TITLE
perf(prefect): pre-filter done partitions with one LIST, not N task runs

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
@@ -205,8 +205,16 @@ def ebi_biosample_extract_flow(
 ) -> None:
     days = _enumerate_days(start=start_day, end=end_day)
     current_key = date.today().isoformat()
+    sem = SemaphoreStore("ebi_biosample")
+    # Single LIST to skip already-done days, instead of one task run +
+    # HEAD per day. The current day always re-runs (it accrues during the
+    # day) when rerun_current_day is set.
+    always = [current_key] if rerun_current_day else []
+    todo = sem.pending_keys(days, always=always, force=force)
+    log = get_run_logger()
+    log.info(f"{len(todo)}/{len(days)} day partitions pending extraction")
     futures = []
-    for key in days:
+    for key in todo:
         force_this = force or (rerun_current_day and key == current_key)
         futures.append(extract_ebi_biosample.submit(key=key, force=force_this))
     for fut in futures:

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -305,8 +305,16 @@ def geo_extract_flow(
     """
     months = _enumerate_months(start=start_month, end=end_month)
     current_key = _month_key(date.today())
+    sem = SemaphoreStore("geo")
+    # Single LIST to skip already-done months, instead of one task run +
+    # HEAD per month. The current month always re-runs (it accrues) when
+    # rerun_current_month is set.
+    always = [current_key] if rerun_current_month else []
+    todo = sem.pending_keys(months, always=always, force=force)
+    log = get_run_logger()
+    log.info(f"{len(todo)}/{len(months)} month partitions pending extraction")
     futures = []
-    for key in months:
+    for key in todo:
         force_this = force or (rerun_current_month and key == current_key)
         futures.append(extract_month.submit(key=key, force=force_this))
     for fut in futures:

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
@@ -367,10 +367,20 @@ def sra_extract_flow(force: bool = False) -> None:
     under `_semaphores/sra/{entity}/{date}_{stage}.json`. Pass force=True
     to re-extract every partition regardless.
     """
+    log = get_run_logger()
     entries = get_mirror_listing()
+    # One LIST per entity namespace to drop already-done partitions, instead
+    # of one task run + HEAD per mirror file. No "always-latest": a new mirror
+    # batch gets new keys, so done == done.
+    done: dict[str, set[str]] = {}
+    if not force:
+        for entity in ENTITIES:
+            done[entity] = set(SemaphoreStore(f"sra/{entity}").list_keys())
     futures = []
     for entry in entries:
         key = _partition_key(entry)
+        if not force and key in done.get(entry["entity"], set()):
+            continue
         stage = "Full" if entry["is_full"] else "Incremental"
         futures.append(
             extract_mirror_file.submit(
@@ -382,6 +392,7 @@ def sra_extract_flow(force: bool = False) -> None:
                 force=force,
             )
         )
+    log.info(f"{len(futures)}/{len(entries)} mirror partitions pending extraction")
     for fut in futures:
         fut.result()
 

--- a/packages/omicidx-prefect/src/omicidx/prefect/semaphore.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/semaphore.py
@@ -75,6 +75,27 @@ class SemaphoreStore:
             return []
         return sorted(p.stem for p in root.iterdir() if p.suffix == ".json")
 
+    def pending_keys(
+        self,
+        candidates,
+        *,
+        always=(),
+        force: bool = False,
+    ) -> list[str]:
+        """Filter `candidates` to the keys that still need work.
+
+        Replaces a per-partition `exists()` HEAD with a single `list_keys()`
+        LIST: enumerate the done set once, then keep any candidate that is
+        either not yet done or named in `always` (e.g. a mutable "latest"
+        partition that must re-run regardless). `force=True` keeps every
+        candidate. Order of `candidates` is preserved.
+        """
+        if force:
+            return list(candidates)
+        done = set(self.list_keys())
+        always = set(always)
+        return [k for k in candidates if k in always or k not in done]
+
     def clear_all(self) -> int:
         """Remove every semaphore in this namespace. Returns count removed."""
         keys = self.list_keys()

--- a/packages/omicidx-prefect/tests/test_flows.py
+++ b/packages/omicidx-prefect/tests/test_flows.py
@@ -104,3 +104,29 @@ def test_semaphore_roundtrip(monkeypatch, tmp_path):
     assert store.clear("2024-09-13_Full") is True
     assert not store.exists("2024-09-13_Full")
     assert store.clear("2024-09-13_Full") is False
+
+
+def test_semaphore_pending_keys(monkeypatch, tmp_path):
+    """pending_keys filters out done partitions via a single list_keys()."""
+    monkeypatch.setenv("PUBLISH_ROOT", str(tmp_path))
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "x")
+    monkeypatch.setenv("S3_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv("S3_REGION", "auto")
+    from omicidx.prefect import config
+
+    config.settings.cache_clear()
+
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    store = SemaphoreStore("geo")
+    store.mark_done("2005-01")
+    store.mark_done("2005-02")
+    candidates = ["2005-01", "2005-02", "2005-03"]
+
+    # done keys dropped, order preserved
+    assert store.pending_keys(candidates) == ["2005-03"]
+    # `always` re-includes a done key (mutable "latest")
+    assert store.pending_keys(candidates, always=["2005-02"]) == ["2005-02", "2005-03"]
+    # force keeps everything
+    assert store.pending_keys(candidates, force=True) == candidates


### PR DESCRIPTION
## Problem

The `sra` / `geo` / `ebi-biosample` extract flows submit **one task per candidate partition**, then check `sem.exists()` *inside* the task. Cost per run:

| Flow | Tasks submitted | Mostly | Per-run cost |
|---|---|---|---|
| ebi-biosample | ~1,960 (per day since 2021-01-01) | skipped | ~1,960 task runs + ~1,960 R2 HEADs |
| geo | ~255 (per month since 2005-01) | skipped | ~255 task runs + HEADs |
| sra | current-batch mirror files | varies | N task runs + HEADs |

>99% of those task runs just log `"semaphore exists, skipping"` after paying a full Prefect task-run lifecycle (state writes, name render, logging) plus one R2 HEAD. That's the thousands of skip lines in the daily-pipeline logs.

## Fix

Add `SemaphoreStore.pending_keys(candidates, *, always=(), force=False)`: a **single `list_keys()` LIST** of the namespace yields the done set, then candidates are filtered to the missing ones. `always` re-includes mutable "latest" partitions (today's ebi day, current geo month) that must re-run regardless; `force` keeps everything.

Wired into all three flow bodies so only pending partitions spawn task runs.

- **ebi**: ~1,960 task runs + HEADs → ~1 task run + 1 LIST/day
- **geo**: same collapse per month
- **sra**: one LIST per entity namespace; done files dropped at submit. No always-latest — a new mirror batch gets new keys, so done == done.

The in-task `sem.exists()` guard stays as cheap defense against overlap races / direct task invocation. Behavior otherwise identical: a present-but-corrupt semaphore is still not retried (same as before); backfills (`clear` semaphores) reappear in the todo set.

## Tests

Added `test_semaphore_pending_keys` (filter / always / force). Full suite: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)