### PR TITLE
fix(prefect): forward PUBLIC_PARQUET_ROOT/HTTPS_BASE to worker

### DIFF
--- a/packages/omicidx-prefect/docker-compose.yml
+++ b/packages/omicidx-prefect/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       S3_REGION: ${S3_REGION:-auto}
       S3_URL_STYLE: ${S3_URL_STYLE:-path}
       PUBLISH_ROOT: ${PUBLISH_ROOT:-s3://omicidx}
+      # Public Parquet target for parquet-export (reverse-ETL, latest/*.parquet)
+      # and the https base the duckdb-build views read from.
+      PUBLIC_PARQUET_ROOT: ${PUBLIC_PARQUET_ROOT}
+      PUBLIC_PARQUET_HTTPS_BASE: ${PUBLIC_PARQUET_HTTPS_BASE}
       # API-serving Postgres (postgres-load target).
       POSTGRES_URI: ${POSTGRES_URI:-postgresql://omicidx@pg_main:5432/omicidx}
       # DuckLake catalog (ducklake-load). Host pg_main resolves on the


### PR DESCRIPTION
## Problem

`parquet-export` task failed:

```
RuntimeError('PUBLIC_PARQUET_ROOT is not set') - Retry 1/1 ...
```

The worker's compose `environment:` block forwarded `PUBLISH_ROOT`, `DUCKLAKE_*`, `POSTGRES_URI`, S3 creds — but **not** the public-parquet vars. `get_public_parquet_path()` raised on the unset root. `duckdb-build` reads `PUBLIC_PARQUET_HTTPS_BASE` the same way and would have failed at the next stage.

Also discovered: the bucket named in docs/config (`r2://data-omicidx`, `data-omicidx.cancerdatasci.org`) **does not exist** (Cloudflare API 404). Public Parquet is currently colocated in the existing `omicidx-test` bucket under `latest/*.parquet`.

## Fix

Forward both vars from the compose `.env`:

```yaml
PUBLIC_PARQUET_ROOT: ${PUBLIC_PARQUET_ROOT}
PUBLIC_PARQUET_HTTPS_BASE: ${PUBLIC_PARQUET_HTTPS_BASE}
```

Local `.env` (gitignored) sets `PUBLIC_PARQUET_ROOT=r2://omicidx-test`. Worker already recreated with the var; export unblocked.

## Follow-ups (not in this PR)

- `PUBLIC_PARQUET_HTTPS_BASE` still blank → `duckdb-build` (020–050 views, which currently reference `https://data-omicidx.cancerdatasci.org/...`) needs a real public https base for whatever bucket serves `latest/`.
- Dedicated public bucket + custom domain (`data-omicidx`) per ADR-0004 remains a later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)