### PR TITLE
fix(prefect): ignore persistent secrets so DuckLake attach isn't ambiguous

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -108,9 +108,17 @@ def _q(value: str) -> str:
 
 
 def get_duckdb_connection(database: str = ":memory:") -> duckdb.DuckDBPyConnection:
-    """Create a DuckDB connection with the R2 secret pre-loaded."""
+    """Create a DuckDB connection with the R2 secret pre-loaded.
+
+    `allow_persistent_secrets=false` makes the connection ignore any
+    on-disk persistent secrets (e.g. a `pg_main` left by interactive
+    catalog bootstrap). The flow creates its own TEMPORARY r2/pg_main/lake
+    secrets; without this, a same-named persistent secret collides and the
+    DuckLake ATTACH fails with "Ambiguity detected for secret name
+    'pg_main', secret occurs in multiple storage backends."
+    """
     s = settings()
-    con = duckdb.connect(database)
+    con = duckdb.connect(database, config={"allow_persistent_secrets": "false"})
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute("SET http_retries = 8;")
     con.execute("SET http_retry_wait_ms = 1000;")


### PR DESCRIPTION
## Problem

`bioproject_to_ducklake` (and any `ducklake-load` task) failed:

```
Failed to attach DuckLake MetaData "__ducklake_metadata_lake":
Ambiguity detected for secret name 'pg_main', secret occurs in
multiple storage backends.
```

`get_ducklake_connection()` creates a **TEMPORARY** `pg_main` postgres secret, but a same-named **PERSISTENT** secret on disk (left by interactive DuckLake catalog bootstrap) shadows it. DuckDB resolves `pg_main` *by name* across both the in-memory and `local_file` backends, finds two, and the DuckLake `ATTACH` (`METADATA_PARAMETERS SECRET 'pg_main'`) errors on the ambiguity.

Only one code path creates `pg_main`, and it's temporary — so the persistent copy comes from outside the flow and lingers in the worker's DuckDB secret store.

## Fix

Open the connection with `allow_persistent_secrets=false` so on-disk secrets are never loaded; the flow's own TEMPORARY `r2`/`pg_main`/`lake` secrets are the only ones visible. Applied at the single chokepoint `get_duckdb_connection()`, so every flow (ducklake-load, parquet-export, duckdb-build) inherits it.

## Verification

Reproduced the exact error by writing a persistent `pg_main` then adding a temporary one → `Ambiguity ... multiple storage backends`. With `allow_persistent_secrets=false` the ambiguity is gone and the attach proceeds to the real postgres connect. Smoke-tested the patched connection: `allow_persistent_secrets = False`, temporary `r2` secret present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)