### PR TITLE
fix(prefect): templatize last hardcoded public-parquet URLs in 020 views

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
+++ b/packages/omicidx-prefect/src/omicidx/prefect/sql/020_base_parquet_views.sql
@@ -14,11 +14,11 @@ create or replace view src_geo_samples as (
 );
 
 -- TODO(derived): geo_series_with_rnaseq_counts is not yet exported by
--- parquet-export (orphaned ducklake loader). Stays on the old consolidated
--- URL until the derived loaders are wired. See plan follow-ups.
+-- parquet-export (orphaned ducklake loader). Lives under the public base at
+-- geo/parquet/ (not latest/) until the derived loaders are wired.
 create or replace view src_geo_series_with_rnaseq_counts as (
     select accession
-    from read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series_with_rnaseq_counts.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/geo/parquet/geo_series_with_rnaseq_counts.parquet')
 );
 
 create or replace view src_geo_platforms as (
@@ -53,11 +53,11 @@ create or replace view src_sra_runs as (
 );
 
 -- TODO(derived): sra_accessions is not yet exported by parquet-export
--- (orphaned ducklake loader). Stays on the old consolidated URL until the
--- derived loaders are wired. See plan follow-ups.
+-- (orphaned ducklake loader). Lives under the public base at sra/parquet/
+-- (not latest/) until the derived loaders are wired.
 create or replace view src_sra_accessions as (
     select *
-    from read_parquet('https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet')
+    from read_parquet('{{PUBLIC_PARQUET_BASE}}/sra/parquet/sra_accessions.parquet')
 );
 
 -----


### PR DESCRIPTION
## Context

Answering "what is `PUBLIC_PARQUET_HTTPS_BASE`": it's the **public HTTPS prefix fronting the public-parquet bucket** — the anonymous read-side counterpart to `PUBLIC_PARQUET_ROOT` (the authenticated `r2://` write side). `duckdb-build`'s `020_base_parquet_views.sql` substitutes `{{PUBLIC_PARQUET_BASE}}` with it so external DuckDB users can read the views without R2 creds.

## Problem

Two views bypassed the placeholder and hardcoded `https://data-omicidx.cancerdatasci.org/...`, a domain that **does not exist** — so `duckdb-build` would fail on them even once `PUBLIC_PARQUET_HTTPS_BASE` is set:

- `src_geo_series_with_rnaseq_counts` → `geo/parquet/geo_series_with_rnaseq_counts.parquet`
- `src_sra_accessions` → `sra/parquet/sra_accessions.parquet`

Both files actually exist in the configured public bucket (`omicidx-test`), served at `https://omicidx-test.cancerdatasci.org`.

## Fix

Swap both to `{{PUBLIC_PARQUET_BASE}}/...` (keeping their `geo/parquet/`/`sra/parquet/` paths — they're not in `latest/` yet, pending derived loaders). Now every view resolves from `PUBLIC_PARQUET_HTTPS_BASE`; no dead-domain refs remain.

Local `.env` (gitignored) now sets `PUBLIC_PARQUET_HTTPS_BASE=https://omicidx-test.cancerdatasci.org` (compose already forwards it, #112).

## Verification

- `grep data-omicidx src/.../sql/` → none.
- `_get_sql("020...")` substitutes cleanly (no placeholder/old domain left).
- Both legacy files read over HTTPS from the configured base: 27,716 and 146,892,912 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)