### PR TITLE
fix(prefect): isolate DuckDB secret_directory instead of disabling persist

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -7,7 +7,9 @@ injecting them as resource parameters.
 """
 
 import asyncio
+import os
 import re
+import tempfile
 from contextlib import contextmanager
 from functools import lru_cache
 from urllib.parse import urlparse
@@ -110,15 +112,26 @@ def _q(value: str) -> str:
 def get_duckdb_connection(database: str = ":memory:") -> duckdb.DuckDBPyConnection:
     """Create a DuckDB connection with the R2 secret pre-loaded.
 
-    `allow_persistent_secrets=false` makes the connection ignore any
-    on-disk persistent secrets (e.g. a `pg_main` left by interactive
-    catalog bootstrap). The flow creates its own TEMPORARY r2/pg_main/lake
-    secrets; without this, a same-named persistent secret collides and the
-    DuckLake ATTACH fails with "Ambiguity detected for secret name
-    'pg_main', secret occurs in multiple storage backends."
+    Point `secret_directory` at a dedicated, app-owned path instead of the
+    default `~/.duckdb/stored_secrets`. The flow only ever creates
+    TEMPORARY (in-memory) r2/pg_main/lake secrets, so this directory stays
+    empty — which sidesteps two failures caused by a stale persistent
+    `pg_main` secret left in the default store by interactive catalog
+    bootstrap:
+
+    - DuckLake ATTACH: "Ambiguity detected for secret name 'pg_main',
+      secret occurs in multiple storage backends" (temp + persistent).
+    - Postgres ATTACH: "Unknown secret storage found: 'local_file'" — the
+      postgres secret scan reads the persisted file's storage tag.
+
+    An isolated empty directory means neither stale file is ever seen, so
+    persistent secrets can stay enabled (disabling them is the wrong lever
+    — it still scans the file and throws the local_file error).
     """
     s = settings()
-    con = duckdb.connect(database, config={"allow_persistent_secrets": "false"})
+    secret_dir = os.path.join(tempfile.gettempdir(), "omicidx-duckdb-secrets")
+    os.makedirs(secret_dir, exist_ok=True)
+    con = duckdb.connect(database, config={"secret_directory": secret_dir})
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute("SET http_retries = 8;")
     con.execute("SET http_retry_wait_ms = 1000;")


### PR DESCRIPTION
## Problem

First full forced pipeline run got 4 stages deep before breaking:

```
raw-extract     COMPLETED
ducklake-load   COMPLETED
parquet-export  COMPLETED
postgres-load   FAILED  -> InvalidInputException: Unknown secret storage found: 'local_file'
```

#113 set `allow_persistent_secrets=false` to dodge a **stale persistent `pg_main` secret** (left in the worker's `~/.duckdb/stored_secrets` by interactive catalog bootstrap). That cleared the DuckLake ATTACH ambiguity — but `postgres-load`'s `ATTACH … (TYPE POSTGRES)` triggers a postgres-secret scan that still **reads the persisted file's storage tag**; with the `local_file` backend unregistered (because persistence was disabled), it throws `Unknown secret storage found: 'local_file'`.

So disabling persistence was the wrong lever: the stale file is still scanned.

## Fix

Point `secret_directory` at a dedicated app-owned path (`<tmpdir>/omicidx-duckdb-secrets`). The flow only ever creates **TEMPORARY (in-memory)** r2/pg_main/lake secrets, so that directory stays empty. The stale `pg_main` in the default store is never seen — which kills **both** failures at once:

- DuckLake ATTACH ambiguity (#113's target) — no persistent `pg_main` in the empty dir.
- Postgres ATTACH `local_file` scan error — no persisted file to scan.

Persistent secrets stay enabled (the correct default).

## Verification

- Reproduced: stale-dir + `persist=false` → `local_file` error; fresh empty `secret_directory` → clean (scan proceeds to the real postgres connect).
- Patched connection: `secret_directory` app-owned, only the in-memory `r2` secret present, postgres attach errors only on the (bogus-host) connection, not on secrets.

Supersedes the approach in #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)