### PR TITLE
perf(prefect): bounded-parallel postgres-load with DuckDB resource caps

### DIFF
--- a/packages/omicidx-prefect/docker-compose.yml
+++ b/packages/omicidx-prefect/docker-compose.yml
@@ -47,6 +47,10 @@ services:
       # shared network; the catalog's stored data_path governs I/O.
       DUCKLAKE_URI: ${DUCKLAKE_URI}
       DUCKLAKE_DATA_PATH: ${DUCKLAKE_DATA_PATH}
+      # DuckDB per-connection caps + parallel postgres-load fan-out.
+      DUCKDB_MEMORY_LIMIT: ${DUCKDB_MEMORY_LIMIT}
+      DUCKDB_THREADS: ${DUCKDB_THREADS}
+      POSTGRES_LOAD_CONCURRENCY: ${POSTGRES_LOAD_CONCURRENCY:-4}
     command:
       - prefect
       - worker

--- a/packages/omicidx-prefect/src/omicidx/prefect/config.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/config.py
@@ -44,6 +44,15 @@ class Settings(BaseSettings):
     public_parquet_https_base: str | None = (
         None  # e.g. https://data-omicidx.cancerdatasci.org
     )
+    # DuckDB per-connection resource caps. Important when several
+    # connections run concurrently (e.g. parallel postgres-load): leave
+    # unset and each connection grabs most of RAM / all cores, so N in
+    # parallel oversubscribe and OOM. Set memory_limit ~= RAM/concurrency
+    # and threads ~= cores/concurrency.
+    duckdb_memory_limit: str | None = None  # e.g. "32GB"
+    duckdb_threads: int | None = None  # e.g. 16
+    # Parallelism for postgres-load (independent per-entity table loads).
+    postgres_load_concurrency: int = 4
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -132,6 +141,10 @@ def get_duckdb_connection(database: str = ":memory:") -> duckdb.DuckDBPyConnecti
     secret_dir = os.path.join(tempfile.gettempdir(), "omicidx-duckdb-secrets")
     os.makedirs(secret_dir, exist_ok=True)
     con = duckdb.connect(database, config={"secret_directory": secret_dir})
+    if s.duckdb_memory_limit:
+        con.execute(f"SET memory_limit = '{_q(s.duckdb_memory_limit)}';")
+    if s.duckdb_threads:
+        con.execute(f"SET threads = {int(s.duckdb_threads)};")
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute("SET http_retries = 8;")
     con.execute("SET http_retry_wait_ms = 1000;")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
@@ -10,6 +10,7 @@ reads the lake tables directly, independent of the public parquet export.
 """
 
 import asyncio
+import os
 import re
 
 from omicidx.prefect.config import (
@@ -23,6 +24,13 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from prefect import flow, get_run_logger, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+# Read at import (avoids triggering full Settings validation here); mirrors
+# Settings.postgres_load_concurrency default. Bounds how many independent
+# per-entity loads run at once — pair with duckdb_memory_limit/threads so
+# concurrent DuckDB connections don't oversubscribe RAM/cores.
+_PG_CONCURRENCY = int(os.getenv("POSTGRES_LOAD_CONCURRENCY", "4"))
 
 
 def _validate_sql_identifier(name: str) -> str:
@@ -645,19 +653,33 @@ def pubmed_postgres() -> int:
     )
 
 
-@flow(name="postgres-load")
+@flow(name="postgres-load", task_runner=ThreadPoolTaskRunner(max_workers=_PG_CONCURRENCY))
 def postgres_load_flow() -> None:
-    """Reload every API-serving table from its DuckLake source table."""
-    bioproject_postgres()
-    biosample_postgres()
-    sra_study_postgres()
-    sra_sample_postgres()
-    sra_experiment_postgres()
-    sra_run_postgres()
-    geo_series_postgres()
-    geo_sample_postgres()
-    geo_platform_postgres()
-    pubmed_postgres()
+    """Reload every API-serving table from its DuckLake source table.
+
+    The 10 per-entity loads are independent (separate tables, A/B slots and
+    views), so they run concurrently bounded by POSTGRES_LOAD_CONCURRENCY.
+    Tasks are submitted largest-table-first (LPT) to minimise makespan: the
+    longest poles start immediately and smaller loads backfill freed slots.
+    DuckDB memory_limit/threads (config) keep concurrent connections from
+    oversubscribing the box.
+    """
+    # Largest → smallest by approximate row count (LPT scheduling).
+    loads = [
+        biosample_postgres,
+        sra_run_postgres,
+        sra_experiment_postgres,
+        pubmed_postgres,
+        sra_sample_postgres,
+        geo_sample_postgres,
+        bioproject_postgres,
+        sra_study_postgres,
+        geo_series_postgres,
+        geo_platform_postgres,
+    ]
+    futures = [t.submit() for t in loads]
+    for f in futures:
+        f.result()  # re-raise any task failure
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`postgres_load_flow` ran its 10 per-entity loads **sequentially** (called directly, not submitted), so wall-clock = sum of all 10 — with biosample/sra_run/sra_experiment/pubmed the long poles. The loads are **independent** (separate tables, A/B backing slots, and views; per-table view swaps), so the serialization is pure waste — each is mostly R2-read + postgres-write **wait**.

## Change

- Run them concurrently via `ThreadPoolTaskRunner(max_workers=POSTGRES_LOAD_CONCURRENCY)` (default **4**), `.submit()` + `.result()` to surface failures.
- Submit **largest-table-first (LPT)** to minimise makespan — long poles start immediately, small loads backfill freed slots.
- **Cap DuckDB per connection** so N concurrent connections don't oversubscribe the box (without a cap each grabs ~all RAM/cores): new `duckdb_memory_limit` + `duckdb_threads` config applied in `get_duckdb_connection`.

Defaults for the 502 GB / 64-core host (in `.env`, forwarded via compose): **32 GB + 16 threads per connection × 4 concurrent = 128 GB / 64 cores**. All three knobs are env-tunable (`DUCKDB_MEMORY_LIMIT`, `DUCKDB_THREADS`, `POSTGRES_LOAD_CONCURRENCY`).

## Safety

No correctness change: loads were already independent, each swaps its own view atomically. Only the wait-overlap changes. The `memory_limit` cap is the non-optional half — it's what makes 4 concurrent DuckDB connections safe.

## Verification

- Patched connection reports `memory_limit=29.8 GiB`, `threads=16`.
- Settings parse: concurrency 4, runner workers 4.
- `pytest test_flows.py` → 5 passed (module import with task_runner OK).

Expected effect: ~25min sequential postgres-load → roughly the biosample long-pole (~15min) with the rest overlapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)