### PR TITLE
fix(prefect): store geo_sample.sra_experiment as VARCHAR not JSON (#109)

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_geo.py
@@ -130,7 +130,10 @@ SELECT * EXCLUDE (rn) FROM (
         trim(scan_protocol) AS scan_protocol,
         data_row_count,
         library_source,
-        sra_experiment,
+        -- read_ndjson_auto(union_by_name=true) infers this scalar accession
+        -- as JSON across the heterogeneous gsm/** partitions; unwrap to a
+        -- plain VARCHAR so joins on the SRX id don't need json trimming (#109).
+        sra_experiment ->> '$' AS sra_experiment,
         trim(data_processing) AS data_processing,
         supplemental_files,
         channels,
@@ -153,7 +156,7 @@ SELECT * EXCLUDE (rn) FROM (
             scan_protocol: trim(scan_protocol),
             data_row_count: data_row_count,
             library_source: library_source,
-            sra_experiment: sra_experiment,
+            sra_experiment: sra_experiment ->> '$',
             data_processing: trim(data_processing),
             supplemental_files: supplemental_files,
             channels: channels,


### PR DESCRIPTION
Fixes #109.

## Problem
`src_geo_samples.sra_experiment` is exposed as a **JSON** type, so values come back as quoted strings (`"SRX185784"`). Joining it against `src_sra_runs` on the SRX id then requires `trim(sra_experiment, '""')` or fails with `Conversion Error: Malformed JSON...`. The accession is always a single scalar, so JSON was never intended.

## Root cause
1. The parser models `sra_experiment` as a plain `str` — the raw NDJSON has a normal string.
2. In `flows/ducklake_geo.py`, `_GEO_SAMPLE_SOURCE` selects `sra_experiment` straight from `read_ndjson_auto(..., union_by_name=true)`. Across the many empty/heterogeneous `gsm/**` partitions, DuckDB infers that column as **JSON**.
3. `merge_to_ducklake` locks the lake table schema on first creation (`CREATE TABLE IF NOT EXISTS ... AS SELECT * ... WHERE false`), so `lake.omicidx.geo_sample.sra_experiment` is permanently JSON.
4. `parquet-export` COPYs that to `geo_samples.parquet` (JSON logical type) → `src_geo_samples` (`select *`) → quoted values.

## Fix
Unwrap the scalar to a plain `VARCHAR` with `sra_experiment ->> '$'` in the `geo_sample` source projection (and the matching `_row_hash` block). The lake column, exported parquet, and `src_geo_samples` then all carry a clean string; NULLs are preserved.

Verified against DuckDB: JSON `"SRX185784"` → VARCHAR `SRX185784`, NULL→NULL, and the `src_sra_runs` join works with no `trim`.

## ⚠️ One-time lake migration required
A code change alone does **not** retype the existing locked table — `CREATE TABLE IF NOT EXISTS` is a no-op on the live `geo_sample`. Before the next `parquet-export` republishes, retype the lake column once, e.g. drop + reload so the fixed projection recreates it as VARCHAR:

```sql
-- in a get_ducklake_connection() session
DROP TABLE lake.omicidx.geo_sample;
```
then
```bash
omicidx-prefect run ducklake-load   # recreates geo_sample with VARCHAR sra_experiment
omicidx-prefect run parquet-export  # republishes geo_samples.parquet
omicidx-prefect run ducklake-maintenance  # reclaim the dropped table's files
```
(Or `ALTER TABLE lake.omicidx.geo_sample ALTER sra_experiment SET DATA TYPE VARCHAR USING sra_experiment ->> '$'` if DuckLake ALTER-type is preferred.)

## Note
The stale `omicidx-dagster` / `omicidx-etl` copies (`010_raw_to_parquet.sql`) carry the same pattern but are not the live data path; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)