### PR TITLE
docs: align pipeline docs with SQLMesh transform + thin marts-only duckdb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,16 +130,17 @@ substrate. Partition state lives in **semaphore JSON files** in the storage
 bucket (not Dagster's event log). Pipeline:
 
 ```
-raw-extract → ducklake-load → parquet-export → postgres-load → duckdb-build
+raw-extract → ducklake-load → transform → parquet-export → postgres-load → duckdb-build
 ```
 
 | Stage | Module | What it does |
 |---|---|---|
 | `raw-extract` | `flows/{sra,geo,biosample,ebi_biosample,pubmed}.py` | NCBI/EBI → raw Parquet/NDJSON on R2 (`PUBLISH_ROOT`), semaphore-gated |
 | `ducklake-load` | `flows/ducklake*.py` | MERGE raw → `lake.omicidx.*` (hash-gated, copy-on-write; SRA high-water-mark incremental) |
-| `parquet-export` | `flows/parquet_export.py` | Reverse-ETL: COPY lake tables → public Parquet `r2://data-omicidx/latest/*.parquet` (ADR-0004) |
+| `transform` | `flows/transform.py` + `transform/` (SQLMesh) | `plan(prod)` materializes `src`→`stg`→`geometadb.*`/`sradb.*` marts as views in the lake |
+| `parquet-export` | `flows/parquet_export.py` | Reverse-ETL: COPY lake tables **and marts** → public Parquet `r2://data-omicidx/latest/*.parquet` + `latest/{sradb,geometadb}/*.parquet` (ADR-0004) |
 | `postgres-load` | `flows/postgres.py` | Reload API-serving Postgres tables from the lake (A/B-slot swap) |
-| `duckdb-build` | `flows/sql.py` + `sql/020–050` | Build `omicidx.duckdb` from the public Parquet via view SQL |
+| `duckdb-build` | `flows/sql.py` | **Thin**: generate `CREATE VIEW` per mart over the public mart Parquet (no re-derivation); marts-only |
 
 - Config: `config.py` (`Settings` + `get_ducklake_connection`, `get_public_parquet_path`, etc.). Key env: `PUBLISH_ROOT`, `DUCKLAKE_URI`, `DUCKLAKE_DATA_PATH`, `PUBLIC_PARQUET_ROOT`, `PUBLIC_PARQUET_HTTPS_BASE`, `POSTGRES_URI`.
 - Catalog topology + MERGE/maintenance conventions: `DUCKLAKE.md`. Public-serving contract: `docs/adrs/0004`.

--- a/docs/src/content/docs/guides/duckdb-snapshot.md
+++ b/docs/src/content/docs/guides/duckdb-snapshot.md
@@ -142,7 +142,7 @@ curl -s https://data.omicidx.cancerdatasci.org/latest/manifest.json
   "transform_sha": "13b9a955…",
   "lake_snapshot_id": 1780,
   "raw_partition_counts": { "sra/study": 70, "geo": 259, … },
-  "tables": [ { "schema": "main", "table": "src_biosamples", "row_count": 57877046 }, … ]
+  "tables": [ { "schema": "sradb", "table": "study", "row_count": 740807 }, … ]
 }
 ```
 

--- a/packages/omicidx-prefect/README.md
+++ b/packages/omicidx-prefect/README.md
@@ -86,9 +86,11 @@ packages/omicidx-prefect/
 │   │   ├── ebi_biosample.py
 │   │   ├── consolidate.py
 │   │   ├── postgres.py
-│   │   ├── sql.py
+│   │   ├── sql.py           # thin duckdb-build (mart views over public Parquet)
+│   │   ├── transform.py     # SQLMesh transform flow (plan/apply)
 │   │   └── main.py          # daily_pipeline_flow
-│   └── sql/                 # DuckDB view SQL (020–050)
+│   ├── transform/           # SQLMesh project: src→stg→geometadb/sradb marts
+│   └── sql/                 # raw→parquet SQL (010 only; 020–050 → SQLMesh)
 └── tests/
 ```
 
@@ -133,9 +135,11 @@ docker compose exec worker prefect deploy --all
 docker compose exec worker prefect deployment ls
 ```
 
-The pipeline is `raw-extract → ducklake-load → parquet-export →
+The pipeline is `raw-extract → ducklake-load → transform → parquet-export →
 postgres-load → duckdb-build`; schedules live in `prefect.yaml`.
-`parquet-export` is the reverse-ETL (lake → public Parquet, ADR-0004).
+`transform` is the SQLMesh mart build (lake views); `parquet-export` is the
+reverse-ETL (lake tables + marts → public Parquet, ADR-0004); `duckdb-build` is
+now a thin set of mart views over that public Parquet.
 
 ## Mapping from Dagster
 


### PR DESCRIPTION
Follow-up to #120. Aligns the operator/user docs with the merged reality and records the verified live run.

## Changes
- **CLAUDE.md** — add `transform` stage to the prefect pipeline table + diagram; correct the `duckdb-build` row (thin mart views, no re-derivation); note `parquet-export` also exports marts.
- **omicidx-prefect/README.md** — add `transform.py` + `transform/` to the file tree, fix the `sql/` comment (010 only), update the pipeline string.
- **guides/duckdb-snapshot.md** — manifest `tables` example now shows a mart (`sradb.study`); the marts-only duckdb no longer emits `main/src_*` rows.

## Verification (live run on main)
`parquet-export` wrote all 12 base tables + 16 marts; thin `duckdb-build` produced all 16 mart views with matching row counts (sradb.study 740,807 · run 43.7M · geometadb.gse 288,675), queryable over anonymous HTTPS with legacy-contract columns (`study_accession`, `gse`, joined `run_with_study`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)