### PR TITLE
feat(sra): collapse dispatch into one table + iter_sra_records

### DIFF
--- a/packages/omicidx-etl/src/omicidx/etl/sra/mirror_parquet.py
+++ b/packages/omicidx-etl/src/omicidx/etl/sra/mirror_parquet.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Iterable
 from xml.etree.ElementTree import ParseError
 
 from loguru import logger
-from omicidx.parsers.sra.parser import sra_object_generator
+from omicidx.parsers.sra.parser import iter_sra_records
 from upath import UPath
 
 from .schema import get_pyarrow_schema
@@ -34,8 +34,7 @@ def iter_sra_record_dicts_from_mirror_url(url: str) -> Iterable[dict]:
     """
     up = UPath(url)
     with up.open("rb") as f_in, gzip.GzipFile(fileobj=f_in, mode="rb") as gz:
-        for obj in sra_object_generator(gz):
-            yield obj.data
+        yield from iter_sra_records(gz)
 
 
 def process_mirror_entry_to_parquet_parts(

--- a/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/sra/parser.py
@@ -8,8 +8,9 @@
 These parsers each parse XML format files of the format
 available from the fullxml api.
 
-The main entry point into this module is the `parse_xml_file`
-function.
+The main streaming entry point is `iter_sra_records`, which yields one
+parsed dict per record element. `parse_xml_file` / `parse_xml_url` are
+thin file/URL adapters over it.
 
 """
 
@@ -28,45 +29,41 @@ from . import pydantic_models
 logger = logging.getLogger(__name__)
 
 
-def parse_xml_url(url: str, entity: str, gz: bool = True):
-    n = 0
+def parse_xml_url(url: str, entity: str | None = None, gz: bool = True):
+    """Fetch an SRA XML document over HTTP and yield parsed record dicts.
 
+    Thin fetch adapter over :func:`iter_sra_records`. Records are dispatched by
+    XML tag; ``entity`` is accepted for backward compatibility but no longer
+    used (dispatch is by tag).
+    """
     resp = httpx.get(url, timeout=120, follow_redirects=True)
     resp.raise_for_status()
-    with gzip.open(BytesIO(resp.content), "rb") as f:
-        for event, element in etree.iterparse(f):
-            if event == "end" and element.tag == entity:
-                rec = globals()["SRA" + entity.title() + "Record"](element).data
-                n += 1
-                if (n % 100000) == 0:
-                    logger.info(f"parsed {entity} {n} entries")
-                element.clear()
-                yield (rec)
-    logger.info(f"parsed {n} entity entries")
+    content = BytesIO(resp.content)
+    with gzip.open(content, "rb") if gz else content as f:
+        yield from iter_sra_records(f)
 
 
 def parse_xml_file(xmlfilename):
-    """Parse an NCBI SRA mirroring XML file
+    """Parse an NCBI SRA mirroring XML file into an iterator of record dicts.
 
-    This function returns an iterator over the
-    records in the xml file, returning a dict
-    of parsed records.
+    Thin file adapter over :func:`iter_sra_records`: opens the file
+    (transparently gunzipping ``.gz``) and yields one parsed dict per
+    STUDY / SAMPLE / RUN / EXPERIMENT / SUBMISSION element. The entity type is
+    detected from the XML tags, so the filename no longer needs to encode it.
 
     For example:
 
     wget --mirror -nH --cut-dirs=3 ftp://ftp.ncbi.nlm.nih.gov/sra/reports/Mirroring/NCBI_SRA_Mirroring_20181027/
 
-    >>> import omicidx.parsers.sra_parsers as sp
+    >>> import omicidx.parsers.sra.parser as sp
     >>> studies = sp.parse_xml_file("NCBI_SRA_Mirroring_20181027/meta_study_set.xml.gz")
     >>> next(studies)
     ...
 
-
     Parameters
     ----------
     xmlfilename : string
-        the filename to be parsed. Can be gzipped. Must include
-        the "entity" name in the filename (eg., "run", "experiment")
+        the filename to be parsed. Can be gzipped.
 
     Returns
     -------
@@ -74,32 +71,9 @@ def parse_xml_file(xmlfilename):
         An iterator of dict records from parsing each xml record.
 
     """
-    if "study" in xmlfilename:
-        entity = "STUDY"
-        sra_parser = SRAStudyRecord
-    elif "run" in xmlfilename:
-        entity = "RUN"
-        sra_parser = SRARunRecord
-    elif "sample" in xmlfilename:
-        entity = "SAMPLE"
-        sra_parser = SRASampleRecord
-    elif "experiment" in xmlfilename:
-        entity = "EXPERIMENT"
-        sra_parser = SRAExperimentRecord
-    else:
-        raise ValueError(f"Cannot infer SRA entity type from filename: {xmlfilename}")
-    n = 0
     open_func = gzip.open if xmlfilename.endswith(".gz") else open
     with open_func(xmlfilename) as f:
-        for event, element in etree.iterparse(f):
-            if event == "end" and element.tag == entity:
-                rec = sra_parser(element).data
-                n += 1
-                if (n % 100000) == 0:
-                    logger.info(f"parsed {entity} {n} entries")
-                element.clear()
-                yield (rec)
-    logger.info(f"parsed {n} entity entries")
+        yield from iter_sra_records(f)
 
 
 def parse_study(xml: etree.Element) -> dict:
@@ -168,18 +142,18 @@ def parse_submission(xml: etree.Element) -> dict:
 
 
 def dict_from_single_xml(txt):
+    """Parse a single standalone SRA XML string into a dict (tag-dispatched)."""
     xml = etree.fromstring(txt)
-    entity = xml.tag.lower()
-    vals = globals()["parse_" + entity](xml)
+    vals = _parse_element(xml)
     vals["entity_type"] = xml.tag.lower()
     return vals
 
 
 def model_from_single_xml(txt):
+    """Parse a single standalone SRA XML string into a pydantic model."""
     xml = etree.fromstring(txt)
     entity = xml.tag.lower()
-    et = globals()["parse_" + entity](xml)
-    return getattr(pydantic_models, "Sra" + entity.capitalize())(**et)
+    return getattr(pydantic_models, "Sra" + entity.capitalize())(**_parse_element(xml))
 
 
 def parse_run(xml: etree.Element) -> dict:
@@ -671,78 +645,78 @@ def try_update(d: dict, value) -> dict:
         return d
 
 
-class SRAXMLRecord:
-    def __init__(self, xml):
-        # if(type(xml) is not xml.etree.ElementTree.Element):
-        #    raise(TypeError('xml should be of type xml.etree.ElementTree.Element'))
-        self.xml = xml
-        self.parse_xml()
-
-    def parse_xml(self):
-        self.data = dict(self.xml.attrib)
-
-
-class SRAExperimentRecord(SRAXMLRecord):
-    def __init__(self, xml):
-        super().__init__(xml)
-
-    def parse_xml(self):
-        """Parse an SRA xml EXPERIMENT element"""
-        xml = self.xml
-        self.data = parse_experiment(xml)
+# ---------------------------------------------------------------------------
+# Entity dispatch: one table (XML tag -> pure parse function) replaces the
+# scattered globals()/filename-substring/dict dispatch mechanisms.
+# ---------------------------------------------------------------------------
+_ENTITY_PARSERS = {
+    "STUDY": parse_study,
+    "SAMPLE": parse_sample,
+    "RUN": parse_run,
+    "EXPERIMENT": parse_experiment,
+    "SUBMISSION": parse_submission,
+}
 
 
-class SRAStudyRecord(SRAXMLRecord):
-    def __init__(self, xml):
-        super().__init__(xml)
-
-    def parse_xml(self):
-        self.data = parse_study(self.xml)
-
-
-class SRASampleRecord(SRAXMLRecord):
-    def __init__(self, xml):
-        super().__init__(xml)
-
-    def parse_xml(self):
-        self.data = parse_sample(self.xml)
+def _parse_element(element: etree.Element) -> dict:
+    """Dispatch one SRA element to its parser by tag; raise on unknown tags."""
+    parse = _ENTITY_PARSERS.get(element.tag.upper())
+    if parse is None:
+        raise ValueError(f"No SRA parser for element tag: {element.tag!r}")
+    return parse(element)
 
 
-class SRASubmissionRecord(SRAXMLRecord):
-    def __init__(self, xml):
-        super().__init__(xml)
+def iter_sra_records(fileobj):
+    """Stream parsed SRA records from an open XML file object.
 
-    def parse_xml(self):
-        self.data = parse_submission(self.xml)
+    The single streaming entry point for SRA XML (NCBI fullxml API output and
+    the mirroring ``meta_*_set`` files). Yields one dict per STUDY / SAMPLE /
+    RUN / EXPERIMENT / SUBMISSION element, dispatched by tag; elements with any
+    other tag are ignored.
+
+    Parameters
+    ----------
+    fileobj:
+        An open binary file-like object of SRA XML (e.g. an already-gunzipped
+        stream). Parsed incrementally via ``iterparse``.
+
+    Yields
+    ------
+    dict
+        One parsed record per recognized element.
+    """
+    n = 0
+    for event, element in etree.iterparse(fileobj):
+        if event != "end":
+            continue
+        parse = _ENTITY_PARSERS.get(element.tag.upper())
+        if parse is None:
+            continue
+        rec = parse(element)
+        element.clear()
+        n += 1
+        if (n % 100000) == 0:
+            logger.info(f"parsed {n} SRA records")
+        yield rec
+    logger.info(f"parsed {n} SRA records")
 
 
-class SRARunRecord(SRAXMLRecord):
-    def __init__(self, xml):
-        super().__init__(xml)
+class SraRecord:
+    """Back-compat wrapper exposing a parsed record dict as ``.data``.
 
-    def parse_xml(self):
-        self.data = parse_run(self.xml)
+    Retained only for :func:`sra_object_generator`; new code should use
+    :func:`iter_sra_records`, which yields dicts directly.
+    """
+
+    def __init__(self, data: dict):
+        self.data = data
 
 
 def sra_object_generator(fh):
-    """Iterate over objects in an SRA meta_XXX_set xml file
+    """Deprecated: iterate SRA objects exposing parsed data via ``.data``.
 
-    :param: fh an open filehandle
-
-    :returns: An iterator over SRA objects. Access actual data
-        as a dict using Object.data
-
+    Prefer :func:`iter_sra_records`, which yields the dicts directly. Kept as a
+    thin shim so existing callers of the ``.data`` contract keep working.
     """
-    from xml.etree import ElementTree as et
-
-    parsers = {
-        "study": SRAStudyRecord,
-        "sample": SRASampleRecord,
-        "run": SRARunRecord,
-        "experiment": SRAExperimentRecord,
-    }
-    validClasses = ["experiment", "run", "study", "sample"]
-    for event, element in et.iterparse(fh):
-        if (element.tag.lower() in validClasses) and (event == "end"):
-            yield parsers.get(element.tag.title().lower())(element)
-            element.clear()
+    for rec in iter_sra_records(fh):
+        yield SraRecord(rec)

--- a/packages/omicidx-parsers/tests/sra/parser/test_sra_xml_parsers.py
+++ b/packages/omicidx-parsers/tests/sra/parser/test_sra_xml_parsers.py
@@ -1,6 +1,7 @@
 """Offline unit tests for SRA XML parser functions using inline XML fixtures."""
 
 import xml.etree.ElementTree as ET
+from io import BytesIO
 
 import pytest
 from omicidx.parsers.sra import parser as sra_parser
@@ -235,6 +236,42 @@ def test_model_from_single_xml_study():
     model = sra_parser.model_from_single_xml(STUDY_XML)
     assert isinstance(model, SraStudy)
     assert model.accession == "SRP000001"
+
+
+# ---------------------------------------------------------------------------
+# iter_sra_records: streaming dispatch by tag
+# ---------------------------------------------------------------------------
+
+
+def _stream(xml_text: str):
+    return list(sra_parser.iter_sra_records(BytesIO(xml_text.encode("utf-8"))))
+
+
+def test_iter_sra_records_yields_dicts_per_element():
+    doc = f"<STUDY_SET>{STUDY_XML}{STUDY_XML}</STUDY_SET>"
+    records = _stream(doc)
+    assert len(records) == 2
+    assert all(isinstance(r, dict) for r in records)
+    assert {r["accession"] for r in records} == {"SRP000001"}
+
+
+def test_iter_sra_records_mixed_entities_in_document_order():
+    doc = f"<SET>{STUDY_XML}{SAMPLE_XML}{RUN_XML}</SET>"
+    accessions = [r["accession"] for r in _stream(doc)]
+    assert accessions == ["SRP000001", "SRS000001", "SRR000001"]
+
+
+def test_iter_sra_records_skips_unknown_tags():
+    # Non-record elements (and the wrapping SET) are ignored, not crashed on.
+    assert _stream("<SET><FOO><BAR/></FOO></SET>") == []
+
+
+def test_sra_object_generator_backcompat_data_attr():
+    # Deprecated shim still exposes parsed dicts via `.data`.
+    doc = f"<STUDY_SET>{STUDY_XML}</STUDY_SET>"
+    objs = list(sra_parser.sra_object_generator(BytesIO(doc.encode("utf-8"))))
+    assert len(objs) == 1
+    assert objs[0].data["accession"] == "SRP000001"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
@@ -15,7 +15,7 @@ from functools import lru_cache
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-from omicidx.parsers.sra.parser import sra_object_generator
+from omicidx.parsers.sra.parser import iter_sra_records
 from omicidx.prefect.config import get_upath
 from omicidx.prefect.semaphore import SemaphoreStore
 from omicidx.prefect.source import run_extraction
@@ -253,8 +253,7 @@ def _partition_key(entry: dict) -> str:
 def _iter_records_from_url(url: str):
     up = UPath(url)
     with up.open("rb") as f_in, gzip.GzipFile(fileobj=f_in, mode="rb") as gz:
-        for obj in sra_object_generator(gz):
-            yield obj.data
+        yield from iter_sra_records(gz)
 
 
 def _write_parquet_chunks(


### PR DESCRIPTION
Closes #137. Architecture review candidate A.

## What

The SRA parser answered `entity → parser` four fragile ways — a filename substring (`if "study" in xmlfilename`), two `globals()` string lookups, and a tag-title dict that crashed (`None(element)`) on an unknown tag — and the five `SRA*Record` classes were shallow pass-throughs whose whole body was `self.data = parse_x(xml)` (deletion test passes).

Deepened behind the **existing public API**:

- One `_ENTITY_PARSERS` table (XML tag → pure `parse_*` function).
- One streaming `iter_sra_records(fileobj) -> Iterator[dict]` that dispatches by tag and safely skips unknown tags (was: crash).
- Deleted the 5 `SRA*Record` classes; replaced with one tiny `SraRecord` back-compat wrapper used only by the retained `sra_object_generator` shim.
- Public entry points kept as thin adapters with the reflection / filename-inference removed from their guts: `parse_xml_file`, `parse_xml_url`, `dict_from_single_xml`, `model_from_single_xml`.

## Callers

- Migrated the two production callers (`etl/sra/mirror_parquet.py`, `prefect/flows/sra.py`) to `iter_sra_records` — dicts directly.
- The retired `omicidx-dagster` package keeps working through the `sra_object_generator` / `.data` shim, unchanged (this is why the public shim was retained rather than deleted).

## Decisions

- **SRA stays on dicts** — no mandatory pydantic pass; matches the production default (`validate_with_schema=False` elsewhere; ~5x slower on the largest source).
- **Public API preserved** — `omicidx-parsers` is a versioned library (1.17.0); the documented `parse_xml_file` and friends remain importable.

## Tests

- New offline tests stream multi-record XML through `iter_sra_records`: dicts, document order, unknown-tag skip, and `.data` back-compat.
- Existing `parse_*` / `dict_from_single_xml` / `model_from_single_xml` tests pass unchanged (same behavior, de-reflected).

Local: 77 passed offline (4 new); no SRA network tests exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgQaGdPVnYhTRt8hV5DBSo