### PR TITLE
refactor(geo): fold four relation extractors into one relations_matching

### DIFF
--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
@@ -222,40 +222,35 @@ def get_geo_entities(txt):
 #####################################
 
 
+def relations_matching(relation_list: list[str], prefix: str) -> list[str]:
+    """Return relations starting with `prefix`, with that prefix stripped.
+
+    The single implementation behind the per-type `get_*_from_relations`
+    helpers; each of those just supplies its prefix.
+    """
+    return [r.removeprefix(prefix) for r in relation_list if r.startswith(prefix)]
+
+
 def get_subseries_from_relations(relation_list: list[str]) -> list[str]:
-    ret = []
-    for i in relation_list:
-        if i.startswith("SuperSeries of:"):
-            ret.append(i.replace("SuperSeries of: ", ""))
-    return ret
+    return relations_matching(relation_list, "SuperSeries of: ")
 
 
 def get_bioprojects_from_relations(relation_list: list[str]) -> list[str]:
-    ret = []
-    for i in relation_list:
-        if i.startswith("BioProject: https://www.ncbi.nlm.nih.gov/bioproject/"):
-            ret.append(
-                i.replace("BioProject: https://www.ncbi.nlm.nih.gov/bioproject/", "")
-            )
-    return ret
+    return relations_matching(
+        relation_list, "BioProject: https://www.ncbi.nlm.nih.gov/bioproject/"
+    )
 
 
 def get_sra_from_relations(relation_list: list[str]) -> list[str]:
-    ret = []
-    for i in relation_list:
-        if i.startswith("SRA: https://www.ncbi.nlm.nih.gov/sra?term="):
-            ret.append(i.replace("SRA: https://www.ncbi.nlm.nih.gov/sra?term=", ""))
-    return ret
+    return relations_matching(
+        relation_list, "SRA: https://www.ncbi.nlm.nih.gov/sra?term="
+    )
 
 
 def get_biosample_from_relations(relation_list: list[str]) -> list[str]:
-    ret = []
-    for i in relation_list:
-        if i.startswith("BioSample: https://www.ncbi.nlm.nih.gov/biosample/"):
-            ret.append(
-                i.replace("BioSample: https://www.ncbi.nlm.nih.gov/biosample/", "")
-            )
-    return ret
+    return relations_matching(
+        relation_list, "BioSample: https://www.ncbi.nlm.nih.gov/biosample/"
+    )
 
 
 def get_channel_characteristics(d: dict, ch: int) -> dict:

--- a/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
+++ b/packages/omicidx-parsers/tests/geo/test_geo_soft_parsers.py
@@ -109,6 +109,16 @@ def test_iter_soft_entities_empty_text():
 # ---------------------------------------------------------------------------
 
 
+def test_relations_matching_filters_and_strips_leading_prefix():
+    rels = ["p:a", "p:b", "other:c"]
+    assert geo_parser.relations_matching(rels, "p:") == ["a", "b"]
+
+
+def test_relations_matching_strips_only_leading_occurrence():
+    # A prefix recurring later in the value is left intact.
+    assert geo_parser.relations_matching(["p:x-p:y"], "p:") == ["x-p:y"]
+
+
 def test_get_subseries_from_relations():
     rels = [
         "SuperSeries of: GSE111",


### PR DESCRIPTION
Closes #139. Architecture review candidate C.

## What

The four `get_*_from_relations` helpers in `geo/parser.py` differed only by a hard-coded prefix literal, each re-implementing the same filter-and-strip loop.

One deep helper now carries the logic:

```python
def relations_matching(relation_list: list[str], prefix: str) -> list[str]:
    return [r.removeprefix(prefix) for r in relation_list if r.startswith(prefix)]
```

The four public functions stay (versioned library API; `get_subseries`/`get_bioprojects`/`get_sra`/`get_biosample` are called from `_parse_single_gse_soft` / `_parse_single_gsm_soft`) but collapse to one-liners that each name their relation type and hold its prefix. Deletion test: removing `relations_matching` puts the loop back in four places.

## Behavior note

Switched from `.replace(prefix, "")` to `str.removeprefix`, so only the *leading* prefix is stripped — more correct, and equivalent for real GEO values (the URL prefixes don't recur inside an accession).

## Tests

- Added a direct `relations_matching` test (filters non-matches; strips only the leading prefix).
- Existing four helper tests + empty/no-match cases pass unchanged.

Local: 24 GEO offline tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgQaGdPVnYhTRt8hV5DBSo