### PR TITLE
docs(geo): describe the module and point at relations_matching

### DIFF
--- a/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
+++ b/packages/omicidx-parsers/src/omicidx/parsers/geo/parser.py
@@ -1,9 +1,9 @@
-"""Usage
+"""GEO SOFT parsing.
 
-Common use will be to get a list of accessions using:
-
-
-
+Fetch and parse a GEO accession with `geo_entity_iterator`, or parse SOFT
+text you already have with the pure `iter_soft_entities`. Typed accessions
+(SRA, BioProject, BioSample, subseries) are pulled from a record's
+`relation` list with `relations_matching`.
 """
 
 import collections


### PR DESCRIPTION
Follow-up to #140. Replaces the empty `"""Usage ..."""` stub at the top of `geo/parser.py` with a one-paragraph module docstring that names the real entry points (`geo_entity_iterator`, `iter_soft_entities`) and points at `relations_matching` for typed-accession extraction.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgQaGdPVnYhTRt8hV5DBSo