### PR TITLE
fix(prefect): time out the daily pipeline, drop the duplicate geo cron

### DIFF
--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -12,7 +12,8 @@
 #   - daily-pipeline:       02:00 UTC (full extract -> lake -> postgres -> build)
 #   - ducklake-maintenance: 04:00 UTC Sunday (cleanup + compact; no expiry — retention unbounded)
 #   - pubmed-extract:       hourly (poll FTP for new PubMed files)
-#   - geo-extract:          06:00 UTC daily (re-fire current month)
+#   (geo-extract has no schedule of its own — daily-pipeline already runs it
+#   with the same parameters; a second 06:00 firing only stacked on the first.)
 
 name: omicidx-prefect
 prefect-version: 3.0.0
@@ -79,15 +80,12 @@ deployments:
   - name: geo-extract
     description: |
       Re-run the GEO monthly extractor (current month always re-fires;
-      historical months skipped if semaphore exists).
+      historical months skipped if semaphore exists). Unscheduled — the
+      same call runs inside daily-pipeline; standalone for ad-hoc runs.
     entrypoint: src/omicidx/prefect/flows/geo.py:geo_extract_flow
     work_pool:
       name: default
       work_queue_name: default
-    schedules:
-      - cron: "0 6 * * *"
-        timezone: UTC
-        active: true
     parameters:
       rerun_current_month: true
       force: false

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -43,7 +43,7 @@ def raw_extract_flow(force: bool = False) -> None:
     pubmed_extract_flow(force=force)
 
 
-@flow(name="daily-pipeline")
+@flow(name="daily-pipeline", timeout_seconds=36000)
 def daily_pipeline_flow(force: bool = False) -> None:
     """Daily pipeline: extract → ducklake-load → transform → parquet-export → postgres → publish.
 
@@ -53,6 +53,11 @@ def daily_pipeline_flow(force: bool = False) -> None:
     Parquet just written. ``publish-bundle`` builds omicidx.duckdb itself
     (Stage B2: duckdb-build output redirected into the bundle), so the old
     standalone ``omicidx-duckdb-build`` no longer runs inside the pipeline.
+
+    ``timeout_seconds=36000`` (10h): historical successful runs take
+    6.3-7h; a stall (e.g. a network call that hangs instead of erroring)
+    should fail loudly well before the 12h "stuck run" automation's
+    backstop, not sit blue in the UI indefinitely.
     """
     raw_extract_flow(force=force)
     ducklake_load_flow()


### PR DESCRIPTION
Triage half of #145 — stop the bleeding. Does not attempt to repair the pipeline.

- `daily_pipeline_flow` gets `timeout_seconds=36000` (10h). Successful historical runs take 6.3–7h, so a stall now fails loudly instead of sitting blue in the UI forever. Since 2026-08-08 every nightly run hung rather than failed, stacking one non-terminal `Running` run per night.
- The standalone `geo-extract` 06:00 cron is removed. `daily-pipeline` (02:00) already calls `geo_extract_flow(force=force)`, and the standalone deployment's parameters (`rerun_current_month: true`, `force: false`) are exactly that call's defaults — it was a pure duplicate that stacked a second GEO extract on the first while it was still running. The deployment stays (unscheduled) for ad-hoc runs, matching `ducklake-load` / `parquet-export` / `postgres-load`.

The 29 zombie `Running` flow runs are being cancelled operationally, and the worker is redeployed so the timeout takes effect. Out of scope here (see #154): why GEO `2020-07` never completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
