### PR TITLE
fix(prefect): drop geo-extract from the daily path so the pipeline drains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ node_modules/
 .idea/
 
 /.claude/handoffs/
+
+# agent worktrees created by the Claude Code harness
+.claude/worktrees/

--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -80,8 +80,10 @@ deployments:
   - name: geo-extract
     description: |
       Re-run the GEO monthly extractor (current month always re-fires;
-      historical months skipped if semaphore exists). Unscheduled — the
-      same call runs inside daily-pipeline; standalone for ad-hoc runs.
+      historical months skipped if semaphore exists). Unscheduled, and NOT
+      called by daily-pipeline — GEO wedges on 2020-07 (#154) and blocked
+      every downstream stage, so it runs only on demand until it moves to
+      its own scheduled EL process.
     entrypoint: src/omicidx/prefect/flows/geo.py:geo_extract_flow
     work_pool:
       name: default

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -20,7 +20,7 @@ from omicidx.prefect.flows.biosample import (
 )
 from omicidx.prefect.flows.ducklake_load import ducklake_load_flow
 from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
-from omicidx.prefect.flows.geo import geo_extract_flow, geo_rna_seq_counts_flow
+from omicidx.prefect.flows.geo import geo_rna_seq_counts_flow
 from omicidx.prefect.flows.parquet_export import parquet_export_flow
 from omicidx.prefect.flows.postgres import postgres_load_flow
 from omicidx.prefect.flows.publish_bundle import publish_bundle_flow
@@ -37,7 +37,12 @@ def raw_extract_flow(force: bool = False) -> None:
     biosample_extract_flow(force=force)
     bioproject_extract_flow(force=force)
     sra_extract_flow(force=force)
-    geo_extract_flow(force=force)
+    # ponytail: geo-extract is deliberately absent. It wedges on 2020-07 and
+    # held the whole pipeline in `Running` from 2026-08-08, so every stage
+    # below it — including the publish — has not run for a month. Four healthy
+    # domains flowing beats five domains blocked. GEO returns as its own
+    # scheduled EL process (#154), not here; ad-hoc runs still work via the
+    # `geo-extract` deployment and `omicidx-prefect run geo-extract`.
     geo_rna_seq_counts_flow()
     ebi_biosample_extract_flow(force=force)
     pubmed_extract_flow(force=force)


### PR DESCRIPTION
Follow-on to #161, closing out the last scope item of #145 ("a clean run of the four healthy domains").

## Why

#161 gave `daily-pipeline` a 10h timeout so a hang fails loudly instead of sitting blue. It does **not** make the pipeline produce. `raw_extract_flow` calls `geo_extract_flow` sequentially at `main.py:40`, GEO still wedges on `2020-07`, so tonight's 02:00 run would die inside raw-extract at hour 10 and `ducklake-load` / `transform` / `parquet-export` / `publish-bundle` / `postgres-load` would still never fire — exactly as they haven't since 2026-08-08. The public snapshot has been frozen at `v2026-07-14` for a month.

Four healthy domains flowing beats five domains blocked.

## What

- `main.py` — drop the `geo_extract_flow` call and its now-unused import. `geo_rna_seq_counts_flow` stays.
- `prefect.yaml` — the `geo-extract` deployment description claimed "the same call runs inside daily-pipeline", which this makes false. Corrected.
- `.gitignore` — ignore `.claude/worktrees/`, which the agent harness creates inside the repo and which `git add -A` otherwise commits as a gitlink.

## What this does not do

GEO is not abandoned and the hang is not diagnosed here — that's #154, where GEO becomes its own scheduled EL process. Ad-hoc GEO runs are unaffected: both the `geo-extract` deployment (`entrypoint: src/omicidx/prefect/flows/geo.py:geo_extract_flow`) and `omicidx-prefect run geo-extract` import from `flows/geo.py` directly.

Accepted cost, per the decision recorded on map #144: GEO data goes stale until #154 lands.

Refs #145, #154