### PR TITLE
chore(prefect): pin the client to 3.7.2 and time out the downstream flows

### DIFF
--- a/packages/omicidx-prefect/Dockerfile
+++ b/packages/omicidx-prefect/Dockerfile
@@ -15,7 +15,12 @@ WORKDIR /opt/prefect/omicidx
 RUN ln -s /opt/prefect/workspace/packages/omicidx-prefect/src /opt/prefect/omicidx/src \
     && ln -s /opt/prefect/workspace/packages/omicidx-prefect/prefect.yaml /opt/prefect/omicidx/prefect.yaml
 
+# Client pinned to the running prefect-server version. Unpinned, every image
+# rebuild floats it (3.7.8 -> 3.8.3 on 2026-08-14 against a 3.7.2 server, which
+# logs a version-mismatch warning on worker start). Bump this only together
+# with the shared prefect-server in monode/infrastructure/compose/prefect/.
 RUN pip install --no-cache-dir \
+    "prefect==3.7.2" \
     /opt/prefect/workspace/packages/omicidx-parsers \
     /opt/prefect/workspace/packages/omicidx-prefect
 

--- a/packages/omicidx-prefect/pyproject.toml
+++ b/packages/omicidx-prefect/pyproject.toml
@@ -8,6 +8,9 @@ authors = [
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
+    # Kept as a range: pinning here is unsatisfiable in the workspace
+    # (prefect 3.7.2 needs cyclopts>=4.8, omicidx-etl caps it below that).
+    # The image's client version is pinned in the Dockerfile instead.
     "prefect>=3.0",
     "omicidx-parsers",
     "pyarrow>=20.0.0",

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_load.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ducklake_load.py
@@ -39,7 +39,10 @@ from omicidx.prefect.flows.sources import OMICIDX_SOURCES
 from prefect import flow
 
 
-@flow(name="ducklake-load")
+# ponytail: timeouts are sized ~3x the slowest completed run in Prefect's
+# history, purely to stop orphans (a ducklake-load once sat Running 35 days).
+# Not a SLA — raise the number if a legitimate run ever trips it.
+@flow(name="ducklake-load", timeout_seconds=14400)  # slowest completed: 78m
 def ducklake_load_flow(lake_schema: str = LAKE_SCHEMA, force: bool = False) -> None:
     """Upsert every entity's raw data into the DuckLake catalog.
 

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/parquet_export.py
@@ -150,7 +150,7 @@ def prune_dated_folders(keep_date: str) -> list[str]:
     return removed
 
 
-@flow(name="parquet-export")
+@flow(name="parquet-export", timeout_seconds=7200)  # slowest completed: 31m
 def parquet_export_flow(date: str | None = None, lake_schema: str = LAKE_SCHEMA) -> str:
     """Export every core lake table to v{date}/ + latest/, prune old folders.
 

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/postgres.py
@@ -645,7 +645,7 @@ def pubmed_postgres() -> int:
     )
 
 
-@flow(name="postgres-load")
+@flow(name="postgres-load", timeout_seconds=43200)  # slowest completed: 8.7h
 def postgres_load_flow() -> None:
     """Reload every API-serving table from its DuckLake source table."""
     bioproject_postgres()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/publish_bundle.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/publish_bundle.py
@@ -218,7 +218,7 @@ def upload_bundle(
     return {"uploaded": [n for _, n in small] + ["data/"]}
 
 
-@flow(name="publish-bundle")
+@flow(name="publish-bundle", timeout_seconds=14400)  # slowest completed: 75m
 def publish_bundle_flow(
     date: str | None = None, tables: list[tuple[str, str]] | None = None
 ) -> dict:


### PR DESCRIPTION
Life support for the surviving Prefect flows during the transition period. Closes nothing on its own — reported back on #164.

## 1. Client version pin

`packages/omicidx-prefect/Dockerfile` pip-installed prefect unpinned, so every image rebuild floated the client. The 2026-08-14 rebuild went 3.7.8 → 3.8.3 against a **3.7.2** server; the worker logs a version-mismatch warning on every start. Confirmed live: `prefect-server` reports 3.7.2, `omicidx-prefect-worker` reports 3.8.3.

Pinned the Dockerfile's `pip install` to `prefect==3.7.2`. Verified by building the image and checking `prefect version` → 3.7.2.

The pin is in the Dockerfile, not `pyproject.toml`, because a workspace-wide `prefect==3.7.2` is unresolvable: prefect 3.7.2 requires `cyclopts>=4.8.0` and `omicidx-etl`'s dev extra caps cyclopts below that (which is also why `uv.lock` sits at prefect 3.6.19). Untangling that is not this ticket's job.

## 2. `timeout_seconds` on the four downstream flows

A `ducklake-load` orphan sat in `Running` for **35 days** before #145 cancelled it. Values are ~3x the slowest *completed* run in Prefect's own run history (all runs on the server, aggregated via `read_flow_runs`):

| flow | slowest completed | `timeout_seconds` |
|---|---|---|
| `ducklake-load` | 78m | 14400 (4h) |
| `parquet-export` | 31m | 7200 (2h) |
| `publish-bundle` | 75m | 14400 (4h) |
| `postgres-load` | 8.7h (typically 4–4.5h) | 43200 (12h) |

`daily-pipeline` keeps its `timeout_seconds=36000` from #161 — untouched.

Out of scope by the ticket's narrowed scope: `flows/{sra,geo,biosample,ebi_biosample,pubmed}.py` (owned by #153–#157) and `flows/main.py`.

## Notes

The worker is **not** rebuilt or restarted here — the 02:00 UTC `daily-pipeline` run is the verification for #163. This lands on the next deliberate rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY
