### PR TITLE
feat(sra): run SRA extraction as a standalone scheduled EL process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,14 @@ raw-extract → ducklake-load → transform → parquet-export → postgres-load
 | Stage | Module | What it does |
 |---|---|---|
 | `raw-extract` | `flows/{sra,geo,biosample,ebi_biosample,pubmed}.py` | NCBI/EBI → raw Parquet/NDJSON on R2 (`PUBLISH_ROOT`), semaphore-gated |
+
+**Extracts are migrating off Prefect onto systemd `--user` timers** (#144/#149).
+`flows/sra.py` is the migrated pilot: no `@flow`/`@task`, stdlib logging, run as
+`python -m omicidx.prefect.flows.sra run`, scheduled by
+`systemd/omicidx-sra-extract.timer`, and removed from `raw_extract_flow`. The
+shared driver `source.py` is now orchestrator-neutral (bounded
+`ThreadPoolExecutor` + tenacity), so the remaining four domains keep working
+unchanged until their own tickets (#154–#157) strip their decorators too.
 | `ducklake-load` | `flows/ducklake*.py` | MERGE raw → `lake.omicidx.*` (hash-gated, copy-on-write; SRA high-water-mark incremental) |
 | `transform` | `flows/transform.py` + `transform/` (SQLMesh) | `plan(prod)` materializes `src`→`stg`→`geometadb.*`/`sradb.*` marts as views in the lake |
 | `parquet-export` | `flows/parquet_export.py` | Reverse-ETL: COPY lake tables **and marts** → public Parquet `r2://data-omicidx/latest/*.parquet` + `latest/{sradb,geometadb}/*.parquet` (ADR-0004) |

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -67,9 +67,9 @@ def run() -> None:
 @run.command("sra")
 @click.option("--force", is_flag=True)
 def run_sra(force: bool) -> None:
-    from omicidx.prefect.flows.sra import sra_extract_flow
+    from omicidx.prefect.flows.sra import sra_extract
 
-    sra_extract_flow(force=force)
+    sra_extract(force=force)
 
 
 @run.command("geo")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -25,7 +25,6 @@ from omicidx.prefect.flows.parquet_export import parquet_export_flow
 from omicidx.prefect.flows.postgres import postgres_load_flow
 from omicidx.prefect.flows.publish_bundle import publish_bundle_flow
 from omicidx.prefect.flows.pubmed import pubmed_extract_flow
-from omicidx.prefect.flows.sra import sra_extract_flow
 from omicidx.prefect.flows.transform import transform_flow
 
 from prefect import flow
@@ -33,10 +32,20 @@ from prefect import flow
 
 @flow(name="raw-extract")
 def raw_extract_flow(force: bool = False) -> None:
-    """Run every raw extractor. Mirrors `daily_extract_schedule`."""
+    """Run the raw extractors that have not yet moved to their own timer.
+
+    Hollowing out on purpose (#149): each domain migrated to a standalone
+    scheduled EL process is removed here in the same change that adds its
+    timer, or it would extract twice — once on its timer, once inside
+    `daily-pipeline`. When the last one goes, `daily-pipeline` is nothing but
+    the downstream chain, which is what #158 replaces.
+    """
     biosample_extract_flow(force=force)
     bioproject_extract_flow(force=force)
-    sra_extract_flow(force=force)
+    # ponytail: sra-extract is deliberately absent. It is the pilot standalone
+    # EL process (#153) and now runs on its own systemd timer
+    # (`systemd/omicidx-sra-extract.timer`); ad-hoc runs are
+    # `python -m omicidx.prefect.flows.sra run` or `omicidx-prefect run sra`.
     # ponytail: geo-extract is deliberately absent. It wedges on 2020-07 and
     # held the whole pipeline in `Running` from 2026-08-08, so every stage
     # below it — including the publish — has not run for a month. Four healthy

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/sra.py
@@ -1,18 +1,26 @@
-"""SRA extract flow.
+"""SRA extract: a standalone scheduled EL process (#153, the pilot for #154-#157).
 
 Partitions are SRA mirror files identified by (entity, date, stage). Each
 file gets a semaphore at `_semaphores/sra/{entity}/{date}_{stage}.json`.
-The flow fetches the current-batch listing, then maps an extract task
+The extractor fetches the current-batch listing, then fans an extract out
 across (entity, date, stage) triples, skipping any with a semaphore.
+
+No orchestrator: run it as `python -m omicidx.prefect.flows.sra run` (that is
+what the systemd unit in `systemd/omicidx-sra-extract.service` does), logs go
+to stdout -> journald, failures trip `OnFailure=ntfy-notify@%N.service`, and
+the semaphores are the per-partition ledger. The module path still says
+`prefect` only because the rename is #160.
 """
 
 import datetime
 import gzip
+import logging
 import re
 import shutil
 import tempfile
 from functools import lru_cache
 
+import click
 import pyarrow as pa
 import pyarrow.parquet as pq
 from omicidx.parsers.sra.parser import iter_sra_records
@@ -21,10 +29,13 @@ from omicidx.prefect.semaphore import SemaphoreStore
 from omicidx.prefect.source import run_extraction
 from upath import UPath
 
-from prefect import flow, get_run_logger, task
-from prefect.task_runners import ThreadPoolTaskRunner
+log = logging.getLogger(__name__)
 
 ENTITIES = ["study", "sample", "experiment", "run"]
+
+#: Concurrent mirror files in flight. Was `ThreadPoolTaskRunner(max_workers=4)`;
+#: kept at 4 so the migration changes the mechanism, not the load on NCBI.
+MAX_WORKERS = 4
 
 
 # ---------------------------------------------------------------------------
@@ -262,7 +273,6 @@ def _write_parquet_chunks(
     out_dir: UPath,
     chunk_size: int = 500_000,
 ) -> tuple[int, int]:
-    log = get_run_logger()
     schema = _get_pyarrow_schema(entity)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -309,22 +319,21 @@ def _mirror_index() -> dict[str, dict]:
 
     The partition key is ``{entity}/{date}_{stage}`` — an opaque string to the
     driver. The entry (url, entity, date, stage) is resolved back here so
-    ``extract(key, force)`` needs no URL argument. Threads (SRA's task runner)
+    ``extract(key, force)`` needs no URL argument. The driver's worker threads
     share this cache, so the mirror is globbed once per run.
     """
     entries = [e for e in _get_mirror_entries() if e["in_current_batch"]]
     return {f"{e['entity']}/{_partition_key(e)}": e for e in entries}
 
 
-@task(retries=2, retry_delay_seconds=60, task_run_name="sra-extract-{key}")
 def extract_sra_partition(key: str, force: bool = False) -> dict:
     """Extract a single SRA mirror file to parquet, gated by a semaphore.
 
     ``key`` is ``{entity}/{date}_{stage}``; the mirror entry (url, date, stage)
     is resolved from the cached listing. Semaphores keep their per-entity
-    layout at ``_semaphores/sra/{entity}/{date}_{stage}.json``.
+    layout at ``_semaphores/sra/{entity}/{date}_{stage}.json``. Retries are the
+    driver's (`run_extraction`), not this function's.
     """
-    log = get_run_logger()
     entry = _mirror_index()[key]
     entity = entry["entity"]
     leaf = _partition_key(entry)
@@ -367,7 +376,7 @@ class SraSource:
     mirror files are immutable — a new batch gets new keys, so done == done.
 
     Partition key is the composite ``{entity}/{date}_{stage}`` (this is what
-    shows up in the Prefect task-run name). Its semaphore, however, keeps the
+    shows up in the log lines). Its semaphore, however, keeps the
     per-entity split: to clear one by hand, run
     ``omicidx-prefect semaphores clear sra/{entity} {date}_{stage}`` — i.e. the
     text before the slash is the namespace suffix, the text after is the key.
@@ -386,11 +395,7 @@ class SraSource:
         ]
 
 
-@flow(
-    name="sra-extract",
-    task_runner=ThreadPoolTaskRunner(max_workers=4),
-)
-def sra_extract_flow(force: bool = False) -> None:
+def sra_extract(force: bool = False, max_workers: int = MAX_WORKERS) -> list[dict]:
     """Extract every current-batch SRA mirror file to parquet.
 
     Each (entity, date, stage) triple is one partition. Semaphores live
@@ -400,8 +405,30 @@ def sra_extract_flow(force: bool = False) -> None:
     # Fresh mirror listing per run: the lru_cache dedups the glob within a run
     # (threads share it) but must not persist across runs in a reused process.
     _mirror_index.cache_clear()
-    run_extraction(SraSource(), force=force)
+    return run_extraction(SraSource(), force=force, max_workers=max_workers)
+
+
+@click.group()
+def cli() -> None:
+    """SRA raw extraction (`python -m omicidx.prefect.flows.sra run`)."""
+
+
+@cli.command("run")
+@click.option("--force", is_flag=True, help="Re-extract every partition.")
+@click.option("--max-workers", default=MAX_WORKERS, show_default=True)
+def run_command(force: bool, max_workers: int) -> None:
+    """Extract every pending SRA mirror partition."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    results = sra_extract(force=force, max_workers=max_workers)
+    extracted = [r for r in results if not r.get("skipped")]
+    rows = sum(r.get("row_count", 0) for r in extracted)
+    click.echo(
+        f"sra: {len(extracted)} partitions extracted "
+        f"({len(results) - len(extracted)} skipped), {rows:,} rows"
+    )
 
 
 if __name__ == "__main__":
-    sra_extract_flow()
+    cli()

--- a/packages/omicidx-prefect/src/omicidx/prefect/source.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/source.py
@@ -11,11 +11,33 @@ scheme, output format, and incrementality cursor behind two methods:
 source's cursor or layout: it only ever sees opaque string keys. This contract
 is precedent-setting (spec §5) — future omicidx sources and sibling producers
 model their extractors on it.
+
+The driver owns fan-out, retries, and logging with no orchestrator involved
+(#149): a bounded ``ThreadPoolExecutor``, tenacity retries, stdlib logging. A
+source is therefore runnable from a systemd unit, a Prefect flow, or a shell —
+none of which it can tell apart.
 """
 
+import concurrent.futures
+import logging
+from collections.abc import Callable
 from typing import Protocol, runtime_checkable
 
-from prefect import Task, get_run_logger
+import tenacity
+
+log = logging.getLogger(__name__)
+
+#: Fan-out width when the caller does not choose one. Small on purpose: every
+#: source in this repo crawls NCBI or EBI, and stacked concurrent runs hammering
+#: those mirrors is the live hypothesis for GEO's 2020-07 wedge (#154). Each
+#: source's own entry point passes its number explicitly.
+DEFAULT_MAX_WORKERS = 4
+
+#: Retry policy for one partition's extract, matching what `@task(retries=2,
+#: retry_delay_seconds=60)` gave us before. Module-level so a test can shrink
+#: the wait; ponytail: one fixed policy for every source until one needs its own.
+RETRY_ATTEMPTS = 3
+RETRY_WAIT_SECONDS = 60
 
 
 @runtime_checkable
@@ -25,9 +47,10 @@ class Source(Protocol):
     #: Semaphore / lake-registry namespace, e.g. "geo", "sra", "pubmed".
     name: str
 
-    #: Prefect task with signature ``(key: str, force: bool) -> dict``. Kept as
-    #: an attribute (not a method) so it stays a submittable ``Task``.
-    extract: Task
+    #: Plain callable ``(key: str, force: bool) -> dict``. Kept as an attribute
+    #: (not a method) so a module-level function can be bound with
+    #: ``staticmethod`` and stay independently callable and testable.
+    extract: Callable[..., dict]
 
     def list_partitions(self, force: bool = False) -> list[str]:
         """Opaque keys that still need extraction this run.
@@ -42,15 +65,40 @@ class Source(Protocol):
         ...
 
 
-def run_extraction(source: Source, force: bool = False) -> list[dict]:
-    """List a source's pending partitions and extract each as a Prefect task.
+def run_extraction(
+    source: Source,
+    force: bool = False,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+) -> list[dict]:
+    """List a source's pending partitions and extract each, bounded and retried.
 
-    The task runner (thread vs process pool, concurrency) is chosen by the
-    calling ``@flow``; this driver just fans ``source.extract`` out across the
-    keys and waits. Returns each extract's result dict.
+    Fans ``source.extract`` across the pending keys on a ``ThreadPoolExecutor``
+    of exactly ``max_workers`` threads — the one lever that decides how hard we
+    hit a source's mirror, so it is a named argument the caller sets, never a
+    number buried here. Each partition is retried per the module's tenacity
+    policy; if a partition still fails, every other partition still finishes and
+    then the first failure is re-raised, so the process exits non-zero (and, on
+    a timer, trips ``OnFailure=``). Results come back in key order.
     """
-    log = get_run_logger()
     keys = source.list_partitions(force=force)
-    log.info(f"{source.name}: {len(keys)} partitions pending extraction")
-    futures = [source.extract.submit(key=key, force=force) for key in keys]
-    return [f.result() for f in futures]
+    log.info(
+        "%s: %d partitions pending extraction (max_workers=%d)",
+        source.name,
+        len(keys),
+        max_workers,
+    )
+    if not keys:
+        return []
+
+    extract = tenacity.retry(
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS),
+        wait=tenacity.wait_fixed(RETRY_WAIT_SECONDS),
+        before_sleep=tenacity.before_sleep_log(log, logging.WARNING),
+        reraise=True,
+    )(source.extract)
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=max_workers, thread_name_prefix=f"{source.name}-extract"
+    ) as pool:
+        futures = [pool.submit(extract, key=key, force=force) for key in keys]
+        return [f.result() for f in futures]

--- a/packages/omicidx-prefect/tests/test_flows.py
+++ b/packages/omicidx-prefect/tests/test_flows.py
@@ -138,47 +138,106 @@ def test_real_sources_conform_to_protocol(monkeypatch, tmp_path):
         s = cls()
         assert isinstance(s, Source), cls.__name__
         assert isinstance(s.name, str) and s.name
-        assert hasattr(s.extract, "submit"), f"{cls.__name__}.extract is not a task"
+        assert callable(s.extract), f"{cls.__name__}.extract is not callable"
+
+
+class _FakeSource:
+    """Minimal Source: 2 pending keys, 3 when forced."""
+
+    name = "fake"
+
+    def __init__(self, extract):
+        self.extract = extract
+
+    def list_partitions(self, force: bool = False) -> list[str]:
+        return ["a", "b", "c"] if force else ["a", "b"]
 
 
 def test_run_extraction_drives_every_key_with_force(monkeypatch, tmp_path):
     """The generic driver lists pending keys and extracts each, threading force."""
     _stub_env(monkeypatch, tmp_path)
     from omicidx.prefect.source import Source, run_extraction
-    from prefect import flow, task
-    from prefect.testing.utilities import prefect_test_harness
 
     calls: list[tuple[str, bool]] = []
 
-    @task
     def fake_extract(key: str, force: bool = False) -> dict:
         calls.append((key, force))
         return {"key": key, "skipped": False}
 
-    class FakeSource:
-        name = "fake"
-        extract = staticmethod(fake_extract)
+    source = _FakeSource(fake_extract)
+    assert isinstance(source, Source)
 
+    results = run_extraction(source, force=False)
+    assert sorted(c[0] for c in calls) == ["a", "b"]
+    assert all(c[1] is False for c in calls)
+    # results come back in key order, not completion order
+    assert [r["key"] for r in results] == ["a", "b"]
+
+    calls.clear()
+    run_extraction(source, force=True)
+    # force reaches both list_partitions (extra key "c") and each extract
+    assert sorted(c[0] for c in calls) == ["a", "b", "c"]
+    assert all(c[1] is True for c in calls)
+
+
+def test_run_extraction_fanout_is_bounded_by_max_workers(monkeypatch, tmp_path):
+    """No more than max_workers extracts are ever in flight — and more than one is."""
+    import threading
+
+    _stub_env(monkeypatch, tmp_path)
+    from omicidx.prefect.source import run_extraction
+
+    lock = threading.Lock()
+    state = {"in_flight": 0, "peak": 0}
+    # Every worker must meet 2 others at the barrier; if the pool were serial (or
+    # narrower than 2) this times out and the test fails loudly rather than flakily.
+    barrier = threading.Barrier(2, timeout=10)
+
+    def slow_extract(key: str, force: bool = False) -> dict:
+        with lock:
+            state["in_flight"] += 1
+            state["peak"] = max(state["peak"], state["in_flight"])
+        barrier.wait()
+        with lock:
+            state["in_flight"] -= 1
+        return {"key": key}
+
+    class Source6(_FakeSource):
         def list_partitions(self, force: bool = False) -> list[str]:
-            return ["a", "b", "c"] if force else ["a", "b"]
+            return [f"k{i}" for i in range(6)]
 
-    assert isinstance(FakeSource(), Source)
+    results = run_extraction(Source6(slow_extract), max_workers=2)
+    assert len(results) == 6
+    assert state["peak"] == 2
 
-    @flow
-    def drive(force: bool = False) -> list[dict]:
-        return run_extraction(FakeSource(), force=force)
 
-    with prefect_test_harness():
-        results = drive(force=False)
-        assert sorted(c[0] for c in calls) == ["a", "b"]
-        assert all(c[1] is False for c in calls)
-        assert len(results) == 2
+def test_run_extraction_retries_then_propagates(monkeypatch, tmp_path):
+    """A partition is retried; a partition that keeps failing fails the whole run."""
+    import pytest
 
-        calls.clear()
-        drive(force=True)
-        # force reaches both list_partitions (extra key "c") and each extract
-        assert sorted(c[0] for c in calls) == ["a", "b", "c"]
-        assert all(c[1] is True for c in calls)
+    _stub_env(monkeypatch, tmp_path)
+    from omicidx.prefect import source as source_mod
+    from omicidx.prefect.source import run_extraction
+
+    monkeypatch.setattr(source_mod, "RETRY_WAIT_SECONDS", 0)
+    attempts: dict[str, int] = {}
+
+    def flaky(key: str, force: bool = False) -> dict:
+        attempts[key] = attempts.get(key, 0) + 1
+        if key == "a" and attempts[key] < 2:
+            raise RuntimeError("transient")
+        if key == "c":
+            raise RuntimeError("permanent")
+        return {"key": key}
+
+    # "a" recovers on its retry, "b" is untouched, so force=False (keys a, b) passes.
+    assert len(run_extraction(_FakeSource(flaky), max_workers=2)) == 2
+    assert attempts["a"] == 2
+
+    # "c" never recovers: exhausts RETRY_ATTEMPTS, then the driver re-raises.
+    with pytest.raises(RuntimeError, match="permanent"):
+        run_extraction(_FakeSource(flaky), force=True, max_workers=2)
+    assert attempts["c"] == source_mod.RETRY_ATTEMPTS
 
 
 def test_semaphore_pending_keys(monkeypatch, tmp_path):

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,42 @@
+# systemd units for omicidx's scheduled EL processes
+
+Source of truth for the units; the copies under `~/.config/systemd/user/` are
+deployment artifacts. Convention (and the rationale for every field) lives in
+`monode/infrastructure/SCHEDULING.md`; the reference implementation is
+`cdsci-lake/systemd/`.
+
+| Unit | Runs | Cadence |
+|---|---|---|
+| `omicidx-sra-extract` | `python -m omicidx.prefect.flows.sra run` | daily 01:00 UTC (+≤30m jitter) |
+
+`ntfy-notify@.service` and `notify-failure.sh` are **not** duplicated here — the
+shared template installed from `cdsci-lake/systemd/` is what every
+`OnFailure=ntfy-notify@%N.service` in this directory resolves to, and one topic
+(`cdsci-lake-ops`) is the whole point. Its alert title says "cdsci-lake job
+failed"; the failing unit name in the body is what identifies it.
+
+## Install (not done by CI — a live-system change, make it deliberately)
+
+```bash
+cp systemd/omicidx-sra-extract.{service,timer} ~/.config/systemd/user/
+# once, shared, if not already present:
+cp ~/Documents/git/cdsci-lake/systemd/ntfy-notify@.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now omicidx-sra-extract.timer
+```
+
+Verify:
+
+```bash
+systemctl --user list-timers omicidx-sra-extract.timer
+systemctl --user start omicidx-sra-extract.service   # one run by hand
+journalctl --user -u omicidx-sra-extract.service -f
+```
+
+Extraction leaves no `lake_ops.run` row by design (#149): it writes raw files to
+R2 and adds no DuckLake snapshot, so the ledger is the per-partition semaphores
+(`omicidx-prefect semaphores list sra/study`), journald is the narrative, and
+ntfy is the failure signal. `ops.run` stays on the load side.
+
+Copy, don't symlink: symlinked units go dangling when a repo moves, and systemd
+then fails to load them silently (this is exactly how `omicidx-sql-runner` died).

--- a/systemd/omicidx-sra-extract.service
+++ b/systemd/omicidx-sra-extract.service
@@ -1,0 +1,35 @@
+# Pilot unit for omicidx's move off Prefect onto systemd --user timers (#153).
+# Instance of the convention in monode/infrastructure's SCHEDULING.md; copied
+# from cdsci-lake/systemd/icite.service, which is the reference implementation.
+#
+# The module path still says `prefect` and no Prefect is involved: the rename
+# is #160, which has to touch every unit file anyway.
+[Unit]
+Description=Extract the current-batch NCBI SRA mirror files to raw parquet on R2
+Documentation=https://github.com/seandavi/omicidx/issues/153
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+# Both jobs pull multi-GB NCBI archives and stream them through pyarrow; running
+# them together contends for bandwidth and memory. Same precedent as pmc/openalex
+# in SCHEDULING.md §4. omicidx-biosample-extract lands in #155 — naming a unit
+# that does not exist yet is inert, not an error.
+Conflicts=omicidx-biosample-extract.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/omicidx
+EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
+ExecStart=/usr/bin/env uv run python -m omicidx.prefect.flows.sra run
+# RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk, verified
+# with `systemd-analyze verify` for cdsci-lake) — use TimeoutStartSec=.
+# A no-op run (every semaphore present) finishes in a couple of minutes: just the
+# Mirroring glob. A real new batch is 4 entities x ~75 mirror files, 4 at a time,
+# the `run` entity alone being hundreds of millions of records. The whole 5-domain
+# raw-extract took 4-5h inside daily-pipeline, so 6h is real headroom for SRA
+# alone without false-alarming on a big-but-healthy night.
+TimeoutStartSec=21600
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/omicidx-sra-extract.timer
+++ b/systemd/omicidx-sra-extract.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Daily NCBI SRA mirror extraction (cadence preserved from daily-pipeline)
+
+[Timer]
+# Daily, the cadence daily-pipeline already ran at (02:00 UTC) — #149 decided to
+# change the mechanism, not the rate. Moved an hour earlier and jittered so the
+# five domain timers stagger across the small hours instead of all firing at once;
+# they used to run *sequentially* inside one flow, so independent timers are a
+# real change in concurrent load. Suggested slotting for the followers:
+# sra 01:00, ebi_biosample 02:00, biosample 04:00, geo 06:00 (pubmed stays hourly).
+# The host is America/Denver, so UTC is stated explicitly.
+OnCalendar=*-*-* 01:00:00 UTC
+RandomizedDelaySec=1800
+# A missed night (box off) catches up on next boot. Cheap: every partition with a
+# semaphore is skipped, so a catch-up run costs one Mirroring glob if nothing is new.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the pilot half of the map's orchestration move (#153; pattern spec in #149).

## What changed

**`source.py` is now orchestrator-neutral** — the reusable deliverable. `Source.extract`
is a plain callable instead of a `prefect.Task`; `run_extraction` fans out on a
`ThreadPoolExecutor` with an explicit `max_workers` argument, retries with tenacity
(the same policy `@task(retries=2, retry_delay_seconds=60)` gave), and logs with stdlib
`logging`. The protocol keeps its two members and its docstring's intent.

```python
def run_extraction(source: Source, force: bool = False,
                   max_workers: int = DEFAULT_MAX_WORKERS) -> list[dict]:
```

`max_workers` is an argument, not a constant in the loop, because it is the one lever
on how hard we hit NCBI/EBI — the live hypothesis for GEO's 2020-07 wedge (#154). SRA
passes `MAX_WORKERS = 4`, the width its `ThreadPoolTaskRunner` already had.

**SRA is standalone**: no `@flow`/`@task`, module logger, `sra_extract()` plus a click
`run` command, so `python -m omicidx.prefect.flows.sra run` is the whole thing.
Semaphores are unchanged and remain the extract ledger — no `ops.run` on the extract
side (#149 decision 2); `ducklake_sra.py` and its `ops.watermark` are untouched.

**SRA is out of `raw_extract_flow`**, in the same change that adds its timer, or it
would extract twice. Same precedent as GEO in 5a11b08.

**`systemd/`** (new, version-controlled, **not installed** — install commands in
`systemd/README.md`): daily `01:00 UTC` + 30m jitter, `Persistent=true`,
`TimeoutStartSec=21600`, `OnFailure=ntfy-notify@%N.service`,
`Conflicts=omicidx-biosample-extract.service`. `ntfy-notify@.service` is deliberately
not duplicated here — the shared template from `cdsci-lake/systemd/` is already
installed and one ntfy topic is the point.

## Verified

`python -m omicidx.prefect.flows.sra run` against prod: 4 pending partitions
(2026-08-14 incremental, all four entities), 62,504 rows, exit 0, semaphores written
with `row_count`/`source_url`/`output_dir`. `systemd-analyze verify --user` clean on
both units.

The four unmigrated domains keep their `@task` extracts and still work — a Prefect task
called from a worker thread runs as a standalone task run (verified), just unparented in
the UI until #154–#157 strip their decorators.

## Tests

`test_flows.py` drops the `prefect_test_harness` from the driver tests and adds two that
pin the new logic: fan-out never exceeds `max_workers` (and is genuinely concurrent, via
a `threading.Barrier` that would time out on a serial pool), and a partition is retried
then its failure propagates out of the driver.

Refs #153, #149, #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
