### PR TITLE
fix(systemd): call uv by absolute path — `env uv` exits 127 under systemd --user

### DIFF
--- a/systemd/omicidx-sra-extract.service
+++ b/systemd/omicidx-sra-extract.service
@@ -20,7 +20,13 @@ Conflicts=omicidx-biosample-extract.service
 Type=oneshot
 WorkingDirectory=/home/davsean/Documents/git/omicidx
 EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
-ExecStart=/usr/bin/env uv run python -m omicidx.prefect.flows.sra run
+# NOT `/usr/bin/env uv` — systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127 "No such file or directory".
+# Verified live: this is why cdsci-lake's retractionwatch.service has failed every
+# night since it was installed. `systemd-analyze verify` does NOT catch it — only
+# actually starting the unit does.
+ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.sra run
 # RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk, verified
 # with `systemd-analyze verify` for cdsci-lake) — use TimeoutStartSec=.
 # A no-op run (every semaphore present) finishes in a couple of minutes: just the


### PR DESCRIPTION
Found by actually installing and starting the #153 pilot unit, which is the only thing that catches it.

## The bug

`ExecStart=/usr/bin/env uv run ...` fails immediately under `systemd --user`. The user manager hands units a minimal PATH:

```
PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin
```

`uv` lives at `~/.local/bin/uv`, which is not on it. Result: exit **127**, `/usr/bin/env: 'uv': No such file or directory`, before a line of omicidx code runs.

`systemd-analyze verify` passes the unit — it only checks syntax. Starting it is the only thing that finds this.

## This is upstream of us

`cdsci-lake/systemd/{icite,retractionwatch}.service` — the reference implementation `monode/infrastructure/SCHEDULING.md` explicitly says to copy instead of its own prose — carry the identical line. Verified on the host:

- `retractionwatch.service`: `status=127` on **Aug 12, 13, and 14**, i.e. every night since install.
- `icite.service`: `journalctl` shows **no entries at all** — it has never run.

Both timers are `enabled`. The failure alerting works perfectly and has been posting to the `cdsci-lake-ops` ntfy topic daily; nothing was watching it. So cdsci-lake's two piloted sources have never actually loaded.

That repo needs the same one-line fix, and SCHEDULING.md's reference snippet should be corrected — neither is in this PR's scope.

## The fix

`ExecStart=%h/.local/bin/uv run ...`. `%h` rather than a hardcoded `/home/davsean` so the unit survives a move; a comment records why, so #154–#157 copy the working form.

Verified: `systemctl --user start omicidx-sra-extract.service` → `Result=success`, `ExecMainStatus=0`, with structured logs in journald.

Refs #153