### PR TITLE
feat(pubmed): run PubMed extraction as a standalone scheduled EL process

### DIFF
--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -11,9 +11,15 @@
 # Schedules:
 #   - daily-pipeline:       02:00 UTC (full extract -> lake -> postgres -> build)
 #   - ducklake-maintenance: 04:00 UTC Sunday (cleanup + compact; no expiry — retention unbounded)
-#   - pubmed-extract:       hourly (poll FTP for new PubMed files)
 #   (geo-extract has no schedule of its own — daily-pipeline already runs it
 #   with the same parameters; a second 06:00 firing only stacked on the first.)
+#
+# Extracts are migrating off Prefect onto systemd --user timers (#149). The
+# `pubmed-extract` deployment is gone (#157): pubmed_extract is no longer a
+# @flow, so there is nothing to deploy. Its hourly cadence lives in
+# `systemd/omicidx-pubmed-extract.timer`. Removing the block from this file does
+# NOT unregister the live schedule — that has to be deleted through the API (see
+# systemd/README.md).
 
 name: omicidx-prefect
 prefect-version: 3.0.0
@@ -65,16 +71,6 @@ deployments:
     schedules:
       - cron: "0 4 * * 0"
         timezone: UTC
-        active: true
-
-  - name: pubmed-extract
-    description: Poll PubMed FTP for new files, extract any missing partitions.
-    entrypoint: src/omicidx/prefect/flows/pubmed.py:pubmed_extract_flow
-    work_pool:
-      name: default
-      work_queue_name: default
-    schedules:
-      - interval: 3600
         active: true
 
   - name: geo-extract

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -101,9 +101,9 @@ def run_bioproject(force: bool) -> None:
 @run.command("pubmed")
 @click.option("--force", is_flag=True)
 def run_pubmed(force: bool) -> None:
-    from omicidx.prefect.flows.pubmed import pubmed_extract_flow
+    from omicidx.prefect.flows.pubmed import pubmed_extract
 
-    pubmed_extract_flow(force=force)
+    pubmed_extract(force=force)
 
 
 @run.command("ebi-biosample")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -24,7 +24,6 @@ from omicidx.prefect.flows.geo import geo_rna_seq_counts_flow
 from omicidx.prefect.flows.parquet_export import parquet_export_flow
 from omicidx.prefect.flows.postgres import postgres_load_flow
 from omicidx.prefect.flows.publish_bundle import publish_bundle_flow
-from omicidx.prefect.flows.pubmed import pubmed_extract_flow
 from omicidx.prefect.flows.transform import transform_flow
 
 from prefect import flow
@@ -54,7 +53,10 @@ def raw_extract_flow(force: bool = False) -> None:
     # `geo-extract` deployment and `omicidx-prefect run geo-extract`.
     geo_rna_seq_counts_flow()
     ebi_biosample_extract_flow(force=force)
-    pubmed_extract_flow(force=force)
+    # ponytail: pubmed-extract is deliberately absent. It now runs on its own
+    # systemd timer (`systemd/omicidx-pubmed-extract.timer`, hourly, the cadence
+    # its retired `pubmed-extract` deployment had); ad-hoc runs are
+    # `python -m omicidx.prefect.flows.pubmed run` or `omicidx-prefect run pubmed`.
 
 
 @flow(name="daily-pipeline", timeout_seconds=36000)

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/pubmed.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/pubmed.py
@@ -1,11 +1,18 @@
-"""PubMed extract flow.
+"""PubMed extract: a standalone scheduled EL process (#157, following #153).
 
 Partitions are individual PubMed XML files (e.g., `pubmed25n0001`).
 Each file gets a semaphore under `_semaphores/pubmed/{file_id}.json`.
-The flow lists the NCBI FTP, maps an extract task across files whose
-semaphores are missing, and writes one parquet per file.
+The extractor lists the NCBI FTP and extracts every file whose semaphore is
+missing, writing one parquet per file.
+
+No orchestrator: run it as `python -m omicidx.prefect.flows.pubmed run` (that
+is what `systemd/omicidx-pubmed-extract.service` does), logs go to stdout ->
+journald, failures trip `OnFailure=ntfy-notify@%N.service`, and the semaphores
+are the per-partition ledger. The module path still says `prefect` only because
+the rename is #160.
 """
 
+import logging
 import re
 import shutil
 import tempfile
@@ -13,6 +20,7 @@ from datetime import datetime
 from functools import lru_cache
 from urllib.request import urlretrieve
 
+import click
 import pubmed_parser as pp
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -21,22 +29,29 @@ from omicidx.prefect.semaphore import SemaphoreStore
 from omicidx.prefect.source import run_extraction
 from upath import UPath
 
-from prefect import flow, get_run_logger, task
-from prefect.task_runners import ProcessPoolTaskRunner
+log = logging.getLogger(__name__)
 
 PUBMED_BASE = UPath("https://ftp.ncbi.nlm.nih.gov/pubmed")
 _XML_GZ_RE = re.compile(r"^(pubmed\d+n\d+)\.xml\.gz$")
+
+#: Concurrent PubMed files in flight. Was `ProcessPoolTaskRunner(max_workers=12)`;
+#: kept at 12 so the migration changes the mechanism, not the load on NCBI.
+#: ponytail: the driver's pool is threads, so the MEDLINE parse is now GIL-bound
+#: where it used to be truly parallel — irrelevant on the typical run (0 pending)
+#: and on incremental days (a handful of files), but an annual baseline drop
+#: (~1,200 files) will be download-bound-then-serial-parse. Swap the driver to a
+#: ProcessPoolExecutor if a baseline year ever runs long enough to matter.
+MAX_WORKERS = 12
 
 
 @lru_cache(maxsize=1)
 def _list_pubmed_files() -> dict[str, str]:
     """List PubMed XML files via HTTPS. Returns {partition_key: url_string}.
 
-    Cached per process: the extract tasks re-resolve a key's URL from this
-    index (a process pool means each worker lists once) so ``extract(key,
-    force)`` stays a uniform two-arg call without the URL leaking through it.
-    # ponytail: per-process re-list, not per-file; pass a prefetched index via
-    # a Prefect variable if the listing cost ever matters.
+    Cached per process: the extracts re-resolve a key's URL from this index so
+    ``extract(key, force)`` stays a uniform two-arg call without the URL leaking
+    through it. The driver's worker threads share this cache, so the FTP is
+    listed once per run.
     """
     result: dict[str, str] = {}
     for subdir in ["baseline", "updatefiles"]:
@@ -60,9 +75,11 @@ def _sanitize_utf8(obj):
     return obj
 
 
-@task(retries=2, retry_delay_seconds=30, task_run_name="pubmed-extract-{key}")
 def extract_pubmed_file(key: str, force: bool = False) -> dict:
-    log = get_run_logger()
+    """Extract a single PubMed XML file to parquet, gated by a semaphore.
+
+    Retries are the driver's (`run_extraction`), not this function's.
+    """
     sem = SemaphoreStore("pubmed")
     if not force and sem.exists(key):
         log.info(f"pubmed/{key}: semaphore exists, skipping")
@@ -135,22 +152,35 @@ class PubmedSource:
         return sorted(set(available) - done)
 
 
-@flow(
-    name="pubmed-extract",
-    task_runner=ProcessPoolTaskRunner(max_workers=12),
-)
-def pubmed_extract_flow(force: bool = False) -> None:
-    """Extract every PubMed file whose semaphore is missing.
-
-    Equivalent to the Dagster pubmed_sensor + pubmed_raw pair: the sensor's
-    job (poll FTP, identify new files) is folded into the source's
-    ``list_partitions``.
-    """
-    # Fresh FTP listing per run: the lru_cache must not persist across runs in
-    # a reused process (workers re-populate it once per run, per process).
+def pubmed_extract(force: bool = False, max_workers: int = MAX_WORKERS) -> list[dict]:
+    """Extract every PubMed file whose semaphore is missing."""
+    # Fresh FTP listing per run: the lru_cache dedups the listing within a run
+    # (threads share it) but must not persist across runs in a reused process.
     _list_pubmed_files.cache_clear()
-    run_extraction(PubmedSource(), force=force)
+    return run_extraction(PubmedSource(), force=force, max_workers=max_workers)
+
+
+@click.group()
+def cli() -> None:
+    """PubMed raw extraction (`python -m omicidx.prefect.flows.pubmed run`)."""
+
+
+@cli.command("run")
+@click.option("--force", is_flag=True, help="Re-extract every partition.")
+@click.option("--max-workers", default=MAX_WORKERS, show_default=True)
+def run_command(force: bool, max_workers: int) -> None:
+    """Extract every pending PubMed partition."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    results = pubmed_extract(force=force, max_workers=max_workers)
+    extracted = [r for r in results if not r.get("skipped")]
+    rows = sum(r.get("row_count", 0) for r in extracted)
+    click.echo(
+        f"pubmed: {len(extracted)} partitions extracted "
+        f"({len(results) - len(extracted)} skipped), {rows:,} rows"
+    )
 
 
 if __name__ == "__main__":
-    pubmed_extract_flow()
+    cli()

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -8,6 +8,7 @@ deployment artifacts. Convention (and the rationale for every field) lives in
 | Unit | Runs | Cadence |
 |---|---|---|
 | `omicidx-sra-extract` | `python -m omicidx.prefect.flows.sra run` | daily 01:00 UTC (+≤30m jitter) |
+| `omicidx-pubmed-extract` | `python -m omicidx.prefect.flows.pubmed run` | hourly (+≤5m jitter) |
 
 `ntfy-notify@.service` and `notify-failure.sh` are **not** duplicated here — the
 shared template installed from `cdsci-lake/systemd/` is what every
@@ -19,19 +20,49 @@ failed"; the failing unit name in the body is what identifies it.
 
 ```bash
 cp systemd/omicidx-sra-extract.{service,timer} ~/.config/systemd/user/
+cp systemd/omicidx-pubmed-extract.{service,timer} ~/.config/systemd/user/
 # once, shared, if not already present:
 cp ~/Documents/git/cdsci-lake/systemd/ntfy-notify@.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now omicidx-sra-extract.timer
+systemctl --user enable --now omicidx-pubmed-extract.timer
 ```
 
-Verify:
+Verify (substitute the unit you just installed):
 
 ```bash
 systemctl --user list-timers omicidx-sra-extract.timer
 systemctl --user start omicidx-sra-extract.service   # one run by hand
 journalctl --user -u omicidx-sra-extract.service -f
 ```
+
+### PubMed only: retire the Prefect schedule in the same change
+
+PubMed is the one domain that had a live standalone Prefect deployment
+(`pubmed-extract`, `interval: 3600`). Deleting the block from `prefect.yaml`
+does **not** unregister it — the schedule stays active in the API (learned the
+hard way in #145). Enable the timer and delete the schedule together, or PubMed
+extracts hourly twice:
+
+```bash
+cd packages/omicidx-prefect
+docker compose exec worker python - <<'PY'
+import asyncio
+from prefect.client.orchestration import get_client
+
+async def main():
+    async with get_client() as client:
+        dep = await client.read_deployment_by_name("pubmed-extract/pubmed-extract")
+        for s in dep.schedules:
+            await client.delete_deployment_schedule(dep.id, s.id)
+        print(f"deleted {len(dep.schedules)} schedule(s) from {dep.id}")
+        await client.delete_deployment(dep.id)   # the flow is no longer a @flow
+asyncio.run(main())
+PY
+```
+
+Confirm with `prefect deployment ls` — no `pubmed-extract`, and
+`systemctl --user list-timers omicidx-pubmed-extract.timer` shows the next fire.
 
 Extraction leaves no `lake_ops.run` row by design (#149): it writes raw files to
 R2 and adds no DuckLake snapshot, so the ledger is the per-partition semaphores

--- a/systemd/omicidx-pubmed-extract.service
+++ b/systemd/omicidx-pubmed-extract.service
@@ -1,0 +1,37 @@
+# Follows the pilot in omicidx-sra-extract.service (#153); pattern decisions in #149.
+# Instance of the convention in monode/infrastructure's SCHEDULING.md.
+#
+# The module path still says `prefect` and no Prefect is involved: the rename
+# is #160, which has to touch every unit file anyway.
+[Unit]
+Description=Extract new NCBI PubMed baseline/update XML files to raw parquet on R2
+Documentation=https://github.com/seandavi/omicidx/issues/157
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+# No Conflicts=: this fires hourly, so declaring a conflict with a daily heavy
+# job would just get pubmed killed (Conflicts= stops the loser, it does not
+# queue it). Pubmed is cheap — a no-op run is two FTP listings.
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/omicidx
+EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
+# NOT `/usr/bin/env uv` — systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127 "No such file or directory".
+# `systemd-analyze verify` does NOT catch it — only actually starting the unit does.
+ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.pubmed run
+# RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk) — use
+# TimeoutStartSec=.
+# The typical run is 2-3 seconds: two FTP listings, "0 partitions pending". An
+# incremental day is a handful of files. But once a year NCBI drops a fresh
+# baseline (~1,200 files, each downloaded, MEDLINE-parsed and written), and that
+# is the run this timeout has to survive without false-alarming. 4h, 12 files in
+# flight. A trigger that lands mid-run is a no-op — systemd will not start a unit
+# that is already active — and semaphores make the next run resume.
+TimeoutStartSec=14400
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/omicidx-pubmed-extract.timer
+++ b/systemd/omicidx-pubmed-extract.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Hourly NCBI PubMed extraction (cadence preserved from the pubmed-extract deployment)
+
+[Timer]
+# Hourly — the cadence the retired Prefect `pubmed-extract` deployment ran at
+# (`interval: 3600`). #149 decided to change the mechanism, not the rate; pubmed
+# is the one domain that is not daily. No timezone needed for an hourly unit.
+OnCalendar=hourly
+# Jitter off the top of the hour so we are not one more thing hitting the NCBI
+# FTP at :00. Small: an hourly poll should not drift far.
+RandomizedDelaySec=300
+# A missed hour (box off) catches up on next boot. Cheap: every file with a
+# semaphore is skipped, so a catch-up run costs two FTP listings if nothing is new.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Applies the #153 pilot pattern to the pubmed domain. Refs #157; pattern decisions in #149.

## What changed

- `flows/pubmed.py` — no `@flow`/`@task`/`ProcessPoolTaskRunner`/`prefect` imports. Module-level `logging.getLogger(__name__)`, `pubmed_extract_flow` → `pubmed_extract(force, max_workers)`, click `run` group at the bottom.
- `flows/main.py` — pubmed removed from `raw_extract_flow` (checklist step 5).
- `cli.py` — `omicidx-prefect run pubmed` calls `pubmed_extract`.
- `prefect.yaml` — the `pubmed-extract` deployment is **deleted**, not just descheduled: `pubmed_extract` is no longer a `@flow`, so the entrypoint would not load.
- `systemd/omicidx-pubmed-extract.{service,timer}` + README row and install commands.

## PubMed is a cutover, not an addition

It is the one domain with a live standalone Prefect schedule (`interval: 3600`). The deployment and the `raw_extract_flow` call go in the same change that adds the timer, or it extracts hourly twice.

**Removing the block from `prefect.yaml` does not unregister the live schedule** (learned in #145). `systemd/README.md` now carries the exact `delete_deployment_schedule` + `delete_deployment` call the installer must run alongside `systemctl --user enable --now`.

## Concurrency note

`ProcessPoolTaskRunner(max_workers=12)` → `MAX_WORKERS = 12` on the shared driver's `ThreadPoolExecutor`. Rate preserved per decision 5, but the MEDLINE parse is now GIL-bound where it used to be truly parallel. Irrelevant on the typical run (0 pending) and on incremental days; a `ponytail:` comment names the ceiling and the ProcessPoolExecutor upgrade path for an annual baseline drop.

## Verified

The exact `ExecStart` ran under `systemd --user` via `systemd-run`: **exit 0, 2.6s**, `pubmed: 0 partitions pending extraction (max_workers=12)` in journald. `%h/.local/bin/uv`, not `env uv` (127). `systemd-analyze --user verify` clean on both units.

`uv run ruff check` / `ruff format --check` / `pytest packages/omicidx-prefect/tests` (14 passed) all green.

Timer is **not** installed — install commands are in `systemd/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY
