### PR TITLE
feat(biosample): run BioSample + BioProject as one standalone scheduled EL process (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,13 @@ raw-extract → ducklake-load → transform → parquet-export → postgres-load
 **Extracts are migrating off Prefect onto systemd `--user` timers** (#144/#149).
 `flows/sra.py` is the migrated pilot: no `@flow`/`@task`, stdlib logging, run as
 `python -m omicidx.prefect.flows.sra run`, scheduled by
-`systemd/omicidx-sra-extract.timer`, and removed from `raw_extract_flow`. The
-shared driver `source.py` is now orchestrator-neutral (bounded
-`ThreadPoolExecutor` + tenacity), so the remaining four domains keep working
-unchanged until their own tickets (#154–#157) strip their decorators too.
+`systemd/omicidx-sra-extract.timer`, and removed from `raw_extract_flow`.
+`flows/biosample.py` followed (#155) — one unit for **both** NCBI full dumps
+(BioSample + BioProject), `systemd/omicidx-biosample-extract.timer`; being
+unpartitioned, it calls its extracts directly instead of via `run_extraction`.
+The shared driver `source.py` is orchestrator-neutral (bounded
+`ThreadPoolExecutor` + tenacity), so any domain not yet migrated keeps working
+unchanged until its own ticket (#154–#157) strips its decorators too.
 | `ducklake-load` | `flows/ducklake*.py` | MERGE raw → `lake.omicidx.*` (hash-gated, copy-on-write; SRA high-water-mark incremental) |
 | `transform` | `flows/transform.py` + `transform/` (SQLMesh) | `plan(prod)` materializes `src`→`stg`→`geometadb.*`/`sradb.*` marts as views in the lake |
 | `parquet-export` | `flows/parquet_export.py` | Reverse-ETL: COPY lake tables **and marts** → public Parquet `r2://data-omicidx/latest/*.parquet` + `latest/{sradb,geometadb}/*.parquet` (ADR-0004) |

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -85,17 +85,17 @@ def run_geo(start_month: str, end_month: str | None, force: bool) -> None:
 @run.command("biosample")
 @click.option("--force", is_flag=True)
 def run_biosample(force: bool) -> None:
-    from omicidx.prefect.flows.biosample import biosample_extract_flow
+    from omicidx.prefect.flows.biosample import biosample_extract
 
-    biosample_extract_flow(force=force)
+    biosample_extract(force=force)
 
 
 @run.command("bioproject")
 @click.option("--force", is_flag=True)
 def run_bioproject(force: bool) -> None:
-    from omicidx.prefect.flows.biosample import bioproject_extract_flow
+    from omicidx.prefect.flows.biosample import bioproject_extract
 
-    bioproject_extract_flow(force=force)
+    bioproject_extract(force=force)
 
 
 @run.command("pubmed")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/biosample.py
@@ -1,26 +1,42 @@
-"""BioSample and BioProject extract flows.
+"""BioSample and BioProject extract: one standalone scheduled EL process (#155).
 
 Neither source is partitioned — each run overwrites the single output
 file. We still emit a semaphore per run (keyed by today's date) so
 operators can see when the last successful run finished.
+
+No orchestrator: run it as `python -m omicidx.prefect.flows.biosample run`
+(that is what `systemd/omicidx-biosample-extract.service` does), logs go to
+stdout -> journald, failures trip `OnFailure=ntfy-notify@%N.service`. The
+module path still says `prefect` only because the rename is #160.
+
+ponytail: no `run_extraction`. That driver exists to fan a source's *many*
+partitions across a bounded pool; here `list_partitions()` returns at most one
+key (today's date), so the pool, the `Source` classes, and the "N partitions
+pending" line were ceremony around a single direct call. The semaphore gate
+lives inside `extract_*` already, so the gating is unchanged. The driver's
+blanket tenacity retry is also the wrong policy for a multi-GB full dump: the
+flaky part is the download, which `_download` already retries on its own, and
+re-pulling gigabytes three times on a parse error would burn the unit's whole
+`TimeoutStartSec=` instead of failing loudly and letting tomorrow's timer retry.
 """
 
 import gzip
+import logging
 import shutil
 import tempfile
 import time
 from datetime import date
 
+import click
 import httpx
 import orjson
 import tenacity
 from omicidx.parsers.biosample import BioProjectParser, BioSampleParser
 from omicidx.prefect.config import get_duckdb_connection, get_duckdb_path, get_upath
 from omicidx.prefect.semaphore import SemaphoreStore
-from omicidx.prefect.source import run_extraction
 from upath import UPath
 
-from prefect import flow, get_run_logger, task
+log = logging.getLogger(__name__)
 
 BIOSAMPLE_URL = "https://ftp.ncbi.nlm.nih.gov/biosample/biosample_set.xml.gz"
 BIOPROJECT_URL = "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml"
@@ -32,7 +48,6 @@ BIOPROJECT_URL = "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml"
     stop=tenacity.stop_after_attempt(5),
 )
 def _download(url: str, dest: str) -> None:
-    log = get_run_logger()
     log.info(f"Downloading {url}")
     with (
         open(dest, "wb") as f,
@@ -52,7 +67,6 @@ def _extract_entity(
     use_gzip_input: bool,
     output_dir: UPath,
 ) -> dict:
-    log = get_run_logger()
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "data.jsonl.gz"
 
@@ -98,9 +112,7 @@ def _extract_entity(
     }
 
 
-@task(retries=2, retry_delay_seconds=30, task_run_name="biosample-extract-{key}")
 def extract_biosample(key: str, force: bool = False) -> dict:
-    log = get_run_logger()
     sem = SemaphoreStore("biosample")
     if not force and sem.exists(key):
         log.info(f"biosample/{key}: semaphore exists, skipping")
@@ -118,9 +130,7 @@ def extract_biosample(key: str, force: bool = False) -> dict:
     return {"key": key, "skipped": False, **meta}
 
 
-@task(retries=2, retry_delay_seconds=30, task_run_name="bioproject-extract-{key}")
 def extract_bioproject(key: str, force: bool = False) -> dict:
-    log = get_run_logger()
     sem = SemaphoreStore("bioproject")
     if not force and sem.exists(key):
         log.info(f"bioproject/{key}: semaphore exists, skipping")
@@ -138,38 +148,16 @@ def extract_bioproject(key: str, force: bool = False) -> dict:
     return {"key": key, "skipped": False, **meta}
 
 
-class _DailyDumpSource:
-    """A single full-dump source keyed by the run date (the ``Source`` protocol).
-
-    BioSample and BioProject are unpartitioned full dumps: one output file,
-    overwritten per run, gated by a per-day semaphore. The subclass sets
-    ``name`` and ``extract``.
-    """
-
-    name: str
-    extract: object
-
-    def list_partitions(self, force: bool = False) -> list[str]:
-        today = date.today().isoformat()
-        return SemaphoreStore(self.name).pending_keys([today], force=force)
-
-
-class BiosampleSource(_DailyDumpSource):
-    name = "biosample"
-    extract = staticmethod(extract_biosample)
-
-
-class BioprojectSource(_DailyDumpSource):
-    name = "bioproject"
-    extract = staticmethod(extract_bioproject)
-
-
-@task(retries=1, retry_delay_seconds=60)
 def bioproject_to_parquet() -> dict:
     """Convert BioProject JSONL → parquet via DuckDB. Always runs (cheap)."""
-    log = get_run_logger()
     input_path = get_duckdb_path("bioproject", "raw", "data.jsonl.gz")
     output_path = get_duckdb_path("bioproject", "parquet", "bioprojects.parquet")
+    # ponytail: kept as-is by the #155 migration (mechanical: same work, no
+    # orchestrator). Nothing in this repo reads
+    # `{PUBLISH_ROOT}/bioproject/parquet/bioprojects.parquet` any more — the
+    # DuckLake loader reads the JSONL, and the public `bioprojects.parquet`
+    # comes out of `parquet_export` from the lake table. Delete when someone
+    # confirms no external consumer; not this ticket's call.
     sql = f"""
         COPY (
             SELECT
@@ -198,17 +186,54 @@ def bioproject_to_parquet() -> dict:
     return {"row_count": row_count, "output_path": output_path}
 
 
-@flow(name="biosample-extract")
-def biosample_extract_flow(force: bool = False) -> None:
-    run_extraction(BiosampleSource(), force=force)
+def biosample_extract(force: bool = False) -> dict:
+    """Extract today's BioSample full dump (no-op if today's semaphore exists)."""
+    return extract_biosample(date.today().isoformat(), force=force)
 
 
-@flow(name="bioproject-extract")
-def bioproject_extract_flow(force: bool = False) -> None:
-    run_extraction(BioprojectSource(), force=force)
+def bioproject_extract(force: bool = False) -> dict:
+    """Extract today's BioProject full dump, then refresh its parquet copy."""
+    result = extract_bioproject(date.today().isoformat(), force=force)
     bioproject_to_parquet()
+    return result
+
+
+@click.group()
+def cli() -> None:
+    """BioSample/BioProject raw extraction.
+
+    (`python -m omicidx.prefect.flows.biosample run`)
+    """
+
+
+@cli.command("run")
+@click.option(
+    "--force", is_flag=True, help="Re-extract even if today's semaphore exists."
+)
+def run_command(force: bool) -> None:
+    """Extract both NCBI full dumps: BioSample, then BioProject.
+
+    One unit, both sources: they are the same machinery over two URLs, each a
+    single unpartitioned file gated by a per-day semaphore, and the DuckLake
+    loader consumes them together. BioSample first, preserving the order
+    `raw_extract_flow` ran them in — so a BioSample failure still blocks
+    BioProject exactly as it did before.
+    """
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    for name, fn in (
+        ("biosample", biosample_extract),
+        ("bioproject", bioproject_extract),
+    ):
+        result = fn(force=force)
+        if result.get("skipped"):
+            click.echo(f"{name}: skipped (semaphore for {result['key']} exists)")
+        else:
+            click.echo(
+                f"{name}: {result['row_count']:,} rows -> {result['output_path']}"
+            )
 
 
 if __name__ == "__main__":
-    biosample_extract_flow()
-    bioproject_extract_flow()
+    cli()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -14,10 +14,6 @@ and the duckdb build. `consolidate.py` is dead once `parquet-export` is
 verified in prod.
 """
 
-from omicidx.prefect.flows.biosample import (
-    bioproject_extract_flow,
-    biosample_extract_flow,
-)
 from omicidx.prefect.flows.ducklake_load import ducklake_load_flow
 from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
 from omicidx.prefect.flows.geo import geo_rna_seq_counts_flow
@@ -39,8 +35,10 @@ def raw_extract_flow(force: bool = False) -> None:
     `daily-pipeline`. When the last one goes, `daily-pipeline` is nothing but
     the downstream chain, which is what #158 replaces.
     """
-    biosample_extract_flow(force=force)
-    bioproject_extract_flow(force=force)
+    # ponytail: biosample/bioproject-extract are deliberately absent. They are
+    # one standalone EL process (#155) on `systemd/omicidx-biosample-extract.timer`;
+    # ad-hoc runs are `python -m omicidx.prefect.flows.biosample run` or
+    # `omicidx-prefect run biosample` / `run bioproject`.
     # ponytail: sra-extract is deliberately absent. It is the pilot standalone
     # EL process (#153) and now runs on its own systemd timer
     # (`systemd/omicidx-sra-extract.timer`); ad-hoc runs are

--- a/packages/omicidx-prefect/tests/test_flows.py
+++ b/packages/omicidx-prefect/tests/test_flows.py
@@ -118,9 +118,14 @@ def _stub_env(monkeypatch, tmp_path):
 
 
 def test_real_sources_conform_to_protocol(monkeypatch, tmp_path):
-    """Every extract flow exposes a Source: name + list_partitions + extract."""
+    """Every *partitioned* extract flow exposes a Source: name + list_partitions + extract.
+
+    biosample/bioproject are absent on purpose: they are unpartitioned full
+    dumps (one file, overwritten per run), so #155 dropped their one-key Source
+    wrappers and calls `extract_*` directly. `test_unpartitioned_extracts_are_direct`
+    covers them instead.
+    """
     _stub_env(monkeypatch, tmp_path)
-    from omicidx.prefect.flows.biosample import BioprojectSource, BiosampleSource
     from omicidx.prefect.flows.ebi_biosample import EbiBiosampleSource
     from omicidx.prefect.flows.geo import GeoSource
     from omicidx.prefect.flows.pubmed import PubmedSource
@@ -132,13 +137,41 @@ def test_real_sources_conform_to_protocol(monkeypatch, tmp_path):
         GeoSource,
         PubmedSource,
         EbiBiosampleSource,
-        BiosampleSource,
-        BioprojectSource,
     ):
         s = cls()
         assert isinstance(s, Source), cls.__name__
         assert isinstance(s.name, str) and s.name
         assert callable(s.extract), f"{cls.__name__}.extract is not callable"
+
+
+def test_unpartitioned_extracts_are_direct(monkeypatch, tmp_path):
+    """biosample/bioproject: keyed by today, semaphore-gated, no fan-out driver."""
+    from datetime import date
+
+    _stub_env(monkeypatch, tmp_path)
+    from omicidx.prefect.flows import biosample as mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        mod,
+        "_extract_entity",
+        lambda **kw: (calls.append(kw["entity"]), {"row_count": 1})[1],
+    )
+    monkeypatch.setattr(mod, "bioproject_to_parquet", lambda: {"row_count": 1})
+
+    today = date.today().isoformat()
+    assert mod.biosample_extract()["key"] == today
+    assert mod.bioproject_extract()["key"] == today
+    assert calls == ["biosample", "bioproject"]
+
+    # Second run of the day is gated by the semaphore each extract just wrote.
+    assert mod.biosample_extract()["skipped"] is True
+    assert mod.bioproject_extract()["skipped"] is True
+    assert calls == ["biosample", "bioproject"]
+
+    # ...unless forced.
+    assert mod.biosample_extract(force=True)["skipped"] is False
+    assert calls == ["biosample", "bioproject", "biosample"]
 
 
 class _FakeSource:

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -8,7 +8,13 @@ deployment artifacts. Convention (and the rationale for every field) lives in
 | Unit | Runs | Cadence |
 |---|---|---|
 | `omicidx-sra-extract` | `python -m omicidx.prefect.flows.sra run` | daily 01:00 UTC (+≤30m jitter) |
+| `omicidx-biosample-extract` | `python -m omicidx.prefect.flows.biosample run` | daily 04:00 UTC (+≤30m jitter) |
 | `omicidx-pubmed-extract` | `python -m omicidx.prefect.flows.pubmed run` | hourly (+≤5m jitter) |
+
+`omicidx-biosample-extract` covers **both** NCBI full dumps (BioSample and
+BioProject) in one unit: same machinery, two URLs, both unpartitioned. It and
+`omicidx-sra-extract` are the two heavy jobs and `Conflicts=` each other — which
+*stops* the loser rather than queueing it, hence the three-hour gap.
 
 `ntfy-notify@.service` and `notify-failure.sh` are **not** duplicated here — the
 shared template installed from `cdsci-lake/systemd/` is what every
@@ -20,21 +26,26 @@ failed"; the failing unit name in the body is what identifies it.
 
 ```bash
 cp systemd/omicidx-sra-extract.{service,timer} ~/.config/systemd/user/
+cp systemd/omicidx-biosample-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-pubmed-extract.{service,timer} ~/.config/systemd/user/
 # once, shared, if not already present:
 cp ~/Documents/git/cdsci-lake/systemd/ntfy-notify@.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now omicidx-sra-extract.timer
+systemctl --user enable --now omicidx-biosample-extract.timer
 systemctl --user enable --now omicidx-pubmed-extract.timer
 ```
 
 Verify (substitute the unit you just installed):
 
 ```bash
-systemctl --user list-timers omicidx-sra-extract.timer
-systemctl --user start omicidx-sra-extract.service   # one run by hand
-journalctl --user -u omicidx-sra-extract.service -f
+systemctl --user list-timers omicidx-biosample-extract.timer
+systemctl --user start omicidx-biosample-extract.service   # one run by hand
+journalctl --user -u omicidx-biosample-extract.service -f
 ```
+
+**Start each unit once by hand before trusting it.** `systemd-analyze verify`
+only checks syntax; it passes a unit whose `ExecStart=` cannot be found at all.
 
 ### PubMed only: retire the Prefect schedule in the same change
 
@@ -66,8 +77,8 @@ Confirm with `prefect deployment ls` — no `pubmed-extract`, and
 
 Extraction leaves no `lake_ops.run` row by design (#149): it writes raw files to
 R2 and adds no DuckLake snapshot, so the ledger is the per-partition semaphores
-(`omicidx-prefect semaphores list sra/study`), journald is the narrative, and
-ntfy is the failure signal. `ops.run` stays on the load side.
+(`omicidx-prefect semaphores list sra/study`, `... list biosample`), journald is
+the narrative, and ntfy is the failure signal. `ops.run` stays on the load side.
 
 Copy, don't symlink: symlinked units go dangling when a repo moves, and systemd
 then fails to load them silently (this is exactly how `omicidx-sql-runner` died).

--- a/systemd/omicidx-biosample-extract.service
+++ b/systemd/omicidx-biosample-extract.service
@@ -1,0 +1,47 @@
+# NCBI BioSample + BioProject as one standalone scheduled EL process (#155),
+# following the pilot in omicidx-sra-extract.service (#153). Convention:
+# monode/infrastructure's SCHEDULING.md.
+#
+# The module path still says `prefect` and no Prefect is involved: the rename
+# is #160, which has to touch every unit file anyway.
+#
+# One unit for both sources on purpose. They are the same machinery over two
+# URLs (biosample_set.xml.gz, bioproject.xml), each a single unpartitioned file
+# gated by a per-day semaphore, and ducklake-load consumes them together. A
+# second timer slot and a second Conflicts= pairing would buy nothing: running
+# them back to back in one unit is what daily-pipeline already did.
+[Unit]
+Description=Extract the NCBI BioSample and BioProject full dumps to raw JSONL on R2
+Documentation=https://github.com/seandavi/omicidx/issues/155
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+# biosample_set.xml.gz is multi-GB and streams through a Python parser; the SRA
+# job crawls the full mirror. Together they contend for bandwidth and memory.
+# Same precedent as pmc/openalex in SCHEDULING.md §4, and the counterpart of the
+# Conflicts= line already in omicidx-sra-extract.service. Conflicts= *stops* the
+# loser rather than queueing it, which is why the OnCalendar slots (01:00 vs
+# 04:00) are three hours apart.
+Conflicts=omicidx-sra-extract.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/omicidx
+EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
+# NOT `/usr/bin/env uv` — systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127. `systemd-analyze verify` does NOT
+# catch it — only actually starting the unit does (#153, and cdsci-lake's
+# retractionwatch.service has failed every night on exactly this).
+ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.biosample run
+# RuntimeMaxSec= silently has no effect on Type=oneshot — use TimeoutStartSec=.
+# This is the heavy job: a multi-GB gzip download plus a full streaming XML parse
+# of ~40M BioSample records into JSONL, then the same for BioProject, then a
+# DuckDB JSONL->parquet pass. Unlike SRA there is no partitioning to resume from,
+# so a timeout throws away the whole night's work — size it well past a slow-FTP
+# night. 10h.
+TimeoutStartSec=36000
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/omicidx-biosample-extract.timer
+++ b/systemd/omicidx-biosample-extract.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily NCBI BioSample + BioProject full-dump extraction (cadence preserved from daily-pipeline)
+
+[Timer]
+# Daily, the cadence daily-pipeline already ran at — #149 decided to change the
+# mechanism, not the rate. 04:00 is this domain's slot in the #153 staggering
+# (sra 01:00, ebi_biosample 02:00, biosample 04:00, geo 06:00; pubmed hourly),
+# three hours clear of the sra job it Conflicts= with, since Conflicts= kills the
+# loser instead of queueing it. The host is America/Denver, so UTC is explicit.
+OnCalendar=*-*-* 04:00:00 UTC
+RandomizedDelaySec=1800
+# A missed night (box off) catches up on next boot. Cheap if today's run already
+# succeeded: the per-day semaphore short-circuits before any download.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the mechanical part of #155 (follower of the #153 pilot, pattern from #149).

## One unit, both sources

`flows/biosample.py` was always two sources in one module. They stay one unit:
same machinery over two NCBI URLs, each a single unpartitioned file gated by a
per-day semaphore, and `ducklake-load` consumes them together. A second timer
slot plus a second `Conflicts=` pairing would buy nothing over running them back
to back — which is what `daily-pipeline` already did. BioSample runs first,
preserving the old order, so a BioSample failure still blocks BioProject exactly
as before.

The unit is named `omicidx-biosample-extract.service`, which is what
`omicidx-sra-extract.service`'s existing `Conflicts=` line already points at —
that reference now binds.

## No `run_extraction` here

`list_partitions()` returned at most one key (today's date), so the bounded
pool, the `_DailyDumpSource`/`BiosampleSource`/`BioprojectSource` wrappers and
the "N partitions pending" line were ceremony around a single direct call. The
semaphore gate already lives inside `extract_*`, so gating is unchanged.

The driver's blanket tenacity retry is also the wrong policy for a multi-GB full
dump: the flaky part is the download, which `_download` already retries on its
own, and re-pulling gigabytes three times on a parse error would burn the whole
`TimeoutStartSec=` instead of failing loudly for the next night's timer. The
protocol serves the sources, not the reverse.

`test_real_sources_conform_to_protocol` now covers the four *partitioned*
sources; `test_unpartitioned_extracts_are_direct` covers these two (keyed by
today, semaphore-gated, `--force` bypasses).

## Scheduling

`OnCalendar=*-*-* 04:00:00 UTC` + `RandomizedDelaySec=1800` — this domain's slot
in the #153 staggering (sra 01:00, ebi_biosample 02:00, biosample 04:00, geo
06:00). Three hours clear of the sra job it `Conflicts=` with, since `Conflicts=`
*stops* the loser rather than queueing it. `TimeoutStartSec=36000` (10h): unlike
SRA there is no partitioning to resume from, so a timeout throws away the whole
night.

## Verified by actually starting it

`ExecStart=%h/.local/bin/uv run ...`, not `env uv` (#153/#168: `systemd --user`'s
minimal PATH excludes `~/.local/bin`, and `systemd-analyze verify` passes the
broken form). Started by hand on the host with a temporary drop-in pointing
`WorkingDirectory=` at this branch's worktree:

```
Result=success  ExecMainStatus=0
biosample/2026-08-14: semaphore exists, skipping
bioproject/2026-08-14: semaphore exists, skipping
Converting r2://omicidx/bioproject/raw/data.jsonl.gz to .../bioprojects.parquet
Wrote 1,103,214 rows
```

The probe install was removed afterwards; **no unit or timer is installed on the
host**. Install commands are in `systemd/README.md`.

## Noted, not changed

`bioproject_to_parquet()` still runs unconditionally (preserved behavior), but
nothing in this repo reads its output any more: `ducklake-load` reads the JSONL,
and the public `bioprojects.parquet` is exported from the lake table by
`parquet_export`. That is 20s and a full 1.1M-row R2 rewrite per night for no
reader. Flagged with a `ponytail:` comment rather than deleted — outside a
mechanical migration's remit.