### PR TITLE
feat(geo): run GEO extraction as a standalone scheduled EL process

### DIFF
--- a/packages/omicidx-prefect/prefect.yaml
+++ b/packages/omicidx-prefect/prefect.yaml
@@ -11,8 +11,6 @@
 # Schedules:
 #   - daily-pipeline:       02:00 UTC (full extract -> lake -> postgres -> build)
 #   - ducklake-maintenance: 04:00 UTC Sunday (cleanup + compact; no expiry — retention unbounded)
-#   (geo-extract has no schedule of its own — daily-pipeline already runs it
-#   with the same parameters; a second 06:00 firing only stacked on the first.)
 #
 # Extracts are migrating off Prefect onto systemd --user timers (#149). The
 # `pubmed-extract` deployment is gone (#157): pubmed_extract is no longer a
@@ -20,6 +18,11 @@
 # `systemd/omicidx-pubmed-extract.timer`. Removing the block from this file does
 # NOT unregister the live schedule — that has to be deleted through the API (see
 # systemd/README.md).
+# The `geo-extract` deployment is gone too (#154): GEO runs on
+# `systemd/omicidx-geo-extract.timer` and its entrypoint symbol
+# `geo_extract_flow` no longer exists. It was never scheduled here, so nothing
+# to unregister — stacked *manual* runs of it were the wedge it got blamed for.
+# Ad-hoc is `omicidx-prefect run geo`.
 
 name: omicidx-prefect
 prefect-version: 3.0.0
@@ -72,21 +75,6 @@ deployments:
       - cron: "0 4 * * 0"
         timezone: UTC
         active: true
-
-  - name: geo-extract
-    description: |
-      Re-run the GEO monthly extractor (current month always re-fires;
-      historical months skipped if semaphore exists). Unscheduled, and NOT
-      called by daily-pipeline — GEO wedges on 2020-07 (#154) and blocked
-      every downstream stage, so it runs only on demand until it moves to
-      its own scheduled EL process.
-    entrypoint: src/omicidx/prefect/flows/geo.py:geo_extract_flow
-    work_pool:
-      name: default
-      work_queue_name: default
-    parameters:
-      rerun_current_month: true
-      force: false
 
   - name: parquet-export
     description: |

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -77,9 +77,9 @@ def run_sra(force: bool) -> None:
 @click.option("--end-month", default=None)
 @click.option("--force", is_flag=True)
 def run_geo(start_month: str, end_month: str | None, force: bool) -> None:
-    from omicidx.prefect.flows.geo import geo_extract_flow
+    from omicidx.prefect.flows.geo import geo_extract
 
-    geo_extract_flow(start_month=start_month, end_month=end_month, force=force)
+    geo_extract(start_month=start_month, end_month=end_month, force=force)
 
 
 @run.command("biosample")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -1,22 +1,50 @@
-"""GEO extract flow.
+"""GEO extract: a standalone scheduled EL process (#154, pattern from #153).
 
 Partitions are calendar months (YYYY-MM). Each month gets a semaphore
-under `_semaphores/geo/{YYYY-MM}.json`. By default the flow processes
+under `_semaphores/geo/{YYYY-MM}.json`. By default the extractor processes
 the current month every run (`rerun_current_month=True`) and skips any
 historical month that already has a semaphore.
 
-A second non-partitioned step (`geo_rna_seq_counts_flow`) refreshes the
-list of GSEs with RNA-seq counts; it has no partitioning.
+No orchestrator: run it as `python -m omicidx.prefect.flows.geo run` (that is
+what `systemd/omicidx-geo-extract.service` does), logs go to stdout ->
+journald, failures trip `OnFailure=ntfy-notify@%N.service`, and the semaphores
+are the per-partition ledger. The module path still says `prefect` only
+because the rename is #160.
+
+`geo_rna_seq_counts_flow` is a separate, non-partitioned refresh of the
+GSEs-with-RNA-seq-counts file. It is NOT part of the extract and still runs
+inside `raw_extract_flow`, so it keeps its Prefect decorators for now.
+
+## Why 2020-07 "hung" (#154)
+
+It did not. A month is one acc.cgi fetch per accession -- 62,419 of them for
+2020-07 -- and `MONTH_FETCH_CONCURRENCY` in-flight requests is the entire
+throughput knob. Measured single-process against live NCBI: **~43 req/s, 22
+minutes for all of 2020-07, 0.2 GB RSS, zero errors**. What actually ran in
+prod was up to 13 stacked `geo-extract` flow runs x
+`ProcessPoolTaskRunner(max_workers=2)` x 30-way asyncio fan-out = up to 780
+concurrent requests at one NCBI endpoint. NCBI degrades under that (measured:
+at 30-wide from a cold client, 10% of requests hit the 30s read timeout and
+throughput fell 10x vs 8-wide), and the semaphore timeline records the result:
+one month completed per **14-23 hours**, i.e. ~1.2 req/s. No month ever
+finished inside a run's lifetime, so no semaphore was written, so the next
+stacked run redid it -- 9 starts of 2020-07, 27 rewrites of 2020-06.
+
+The fix is therefore the *shape* of the run, not the extractor: one process,
+one month at a time (`MAX_WORKERS = 1`), fan-out only inside the month. The
+guards below make a genuinely pathological month loud instead of silent.
 """
 
 import asyncio
 import gzip
+import logging
 import re
 import shutil
 import tempfile
 import time
 from datetime import date, datetime, timedelta
 
+import click
 import httpx
 import orjson
 import polars as pl
@@ -29,11 +57,47 @@ from omicidx.prefect.source import run_extraction
 from upath import UPath
 
 from prefect import flow, get_run_logger, task
-from prefect.task_runners import ProcessPoolTaskRunner
+
+log = logging.getLogger(__name__)
+
+#: Months extracted in parallel. **One.** Was `ProcessPoolTaskRunner(max_workers=2)`.
+#: Unlike sra, a GEO partition is not one file -- it is tens of thousands of
+#: requests already fanned `MONTH_FETCH_CONCURRENCY`-wide at a single NCBI
+#: endpoint. A second month in flight buys no parallelism the month does not
+#: already have; it only doubles the load on the endpoint that wedged (#154).
+MAX_WORKERS = 1
+
+#: In-flight acc.cgi requests within one month. 30 measured clean single-process
+#: (43 req/s sustained over 62,419 accessions). Raise this and you are back in
+#: the regime that produced the wedge -- it is the one knob that matters.
+MONTH_FETCH_CONCURRENCY = 30
+
+#: Wall-clock ceiling for one month's fetch. A full month measured 22 min, so
+#: this is ~5x headroom: a month that blows through it is pathological and
+#: should fail the process (and trip `OnFailure=`) rather than grind silently,
+#: which is exactly what nobody noticed for six years' worth of months.
+MONTH_TIMEOUT_SECONDS = 7200
+
+#: Fraction of a month's accessions that may fail to fetch before the month is
+#: not "done". Individual accessions do get withdrawn from GEO, so this is not
+#: zero; but 2020-06 was marked done having written 68,296 of 73,548 GSMs (7%
+#: silently dropped by `return_exceptions=True`), and a semaphore that says
+#: "done" over a 7% hole is worse than a failure.
+MAX_FETCH_FAILURE_RATE = 0.02
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _is_retryable(e: BaseException) -> bool:
+    """Transport hiccups and NCBI backpressure -- not 4xx, which never heals."""
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code == 429 or 500 <= e.response.status_code < 600
+    return isinstance(
+        e, httpx.RemoteProtocolError | httpx.ConnectError | httpx.TimeoutException
+    )
 
 
 def _month_key(partition_date: date) -> str:
@@ -59,20 +123,7 @@ def _entrezid_to_geo(entrezid: str) -> str:
 @tenacity.retry(
     wait=tenacity.wait_exponential_jitter(2, 60),
     stop=tenacity.stop_after_attempt(8),
-    retry=tenacity.retry_if_exception(
-        lambda e: (
-            (
-                isinstance(e, httpx.HTTPStatusError)
-                and (
-                    e.response.status_code == 429 or 500 <= e.response.status_code < 600
-                )
-            )
-            or isinstance(
-                e,
-                httpx.RemoteProtocolError | httpx.ConnectError | httpx.TimeoutException,
-            )
-        )
-    ),
+    retry=tenacity.retry_if_exception(_is_retryable),
 )
 async def _fetch_accessions(start_date: date, end_date: date) -> list[str]:
     accessions: list[str] = []
@@ -111,6 +162,7 @@ async def _fetch_accessions(start_date: date, end_date: date) -> list[str]:
 @tenacity.retry(
     wait=tenacity.wait_exponential_jitter(2, 30),
     stop=tenacity.stop_after_attempt(5),
+    retry=tenacity.retry_if_exception(_is_retryable),
 )
 async def _fetch_soft(accession: str, client: httpx.AsyncClient) -> str:
     params = {
@@ -127,25 +179,46 @@ async def _fetch_soft(accession: str, client: httpx.AsyncClient) -> str:
 
 
 async def _fetch_and_parse(
-    accessions: list[str], concurrency: int = 30
-) -> dict[str, list[dict]]:
+    accessions: list[str],
+    concurrency: int = MONTH_FETCH_CONCURRENCY,
+    timeout_seconds: int = MONTH_TIMEOUT_SECONDS,
+) -> tuple[dict[str, list[dict]], int]:
+    """Fetch + parse every accession's SOFT record. Returns (records, n_failed).
+
+    Failures are tolerated per-accession (accessions do get withdrawn) but
+    *counted* and returned, so the caller can refuse to mark a month done over
+    a large hole. They used to vanish into `return_exceptions=True`.
+    """
     results: dict[str, list[dict]] = {"GSE": [], "GSM": [], "GPL": []}
     semaphore = asyncio.Semaphore(concurrency)
+    failed = 0
 
     async def _one(acc: str, client: httpx.AsyncClient) -> None:
+        nonlocal failed
         async with semaphore:
-            text = await _fetch_soft(acc, client)
+            try:
+                text = await _fetch_soft(acc, client)
+            except Exception as exc:  # noqa: BLE001 - counted, then reported
+                failed += 1
+                log.warning(
+                    "geo: %s fetch failed: %s: %s", acc, type(exc).__name__, exc
+                )
+                return
             for entity in gp.iter_soft_entities(text):
                 prefix = entity.accession[:3]
                 if prefix in results:
                     results[prefix].append(entity.model_dump())
 
     async with httpx.AsyncClient(timeout=30) as client:
-        await asyncio.gather(
-            *(_one(acc, client) for acc in accessions), return_exceptions=True
-        )
+        # The deadline is the loud guard: every socket here already has a
+        # timeout, so nothing blocks forever, but "62k requests at 1.2/s"
+        # looks exactly like a hang from outside. This turns it into a crash.
+        async with asyncio.timeout(timeout_seconds):
+            await asyncio.gather(
+                *(_one(acc, client) for acc in accessions), return_exceptions=True
+            )
 
-    return results
+    return results, failed
 
 
 def _write_ndjson_gz(records: list[dict], path: UPath) -> int:
@@ -172,38 +245,49 @@ def _write_ndjson_gz(records: list[dict], path: UPath) -> int:
 # ---------------------------------------------------------------------------
 
 
-@task(retries=2, retry_delay_seconds=60, task_run_name="geo-extract-{key}")
 def extract_month(key: str, force: bool = False) -> dict:
     """Extract one calendar-month partition of GEO metadata.
 
     The current month always re-extracts (it accrues records during the month);
     a past month with a semaphore is skipped unless ``force``.
     """
-    log = get_run_logger()
     sem = SemaphoreStore("geo")
 
     # "Current month is volatile" is defined in two paired places: GeoSource.
     # list_partitions keeps it pending (always=[current]); this guard makes it
     # never skip on a stale semaphore. Change both together.
     if not force and key != _month_key(date.today()) and sem.exists(key):
-        log.info(f"geo/{key}: semaphore exists, skipping")
+        log.info("geo/%s: semaphore exists, skipping", key)
         return {"key": key, "skipped": True}
 
     partition_date = datetime.strptime(key, "%Y-%m").date()
     start_date, end_date = _month_range(partition_date)
     output_base = get_upath("geo", "raw")
 
-    log.info(f"Processing GEO {start_date} to {end_date}")
+    log.info("geo/%s: processing %s to %s", key, start_date, end_date)
 
     accessions = asyncio.run(_fetch_accessions(start_date, end_date))
-    log.info(f"Found {len(accessions)} accessions for {key}")
+    log.info("geo/%s: %d accessions", key, len(accessions))
 
     counts = {"GSE": 0, "GSM": 0, "GPL": 0}
 
     if accessions:
-        parsed = asyncio.run(_fetch_and_parse(accessions))
+        started = time.monotonic()
+        parsed, failed = asyncio.run(_fetch_and_parse(accessions))
+        log.info(
+            "geo/%s: fetched %d accessions in %.1f min (%d failed)",
+            key,
+            len(accessions),
+            (time.monotonic() - started) / 60,
+            failed,
+        )
+        if failed > len(accessions) * MAX_FETCH_FAILURE_RATE:
+            raise RuntimeError(
+                f"geo/{key}: {failed}/{len(accessions)} accessions failed to fetch "
+                f"(> {MAX_FETCH_FAILURE_RATE:.0%}); refusing to mark the month done"
+            )
     else:
-        parsed = {"GSE": [], "GSM": [], "GPL": []}
+        parsed, failed = {"GSE": [], "GSM": [], "GPL": []}, 0
 
     for prefix, entity in [("GSE", "gse"), ("GSM", "gsm"), ("GPL", "gpl")]:
         path = (
@@ -215,17 +299,19 @@ def extract_month(key: str, force: bool = False) -> dict:
         )
         n = _write_ndjson_gz(parsed[prefix], path)
         counts[prefix] = n
-        log.info(f"Wrote {n} {prefix} records to {path}")
+        log.info("geo/%s: wrote %d %s records to %s", key, n, prefix, path)
 
     sem.mark_done(
         key,
         metadata={
             "start_date": start_date.isoformat(),
             "end_date": end_date.isoformat(),
+            "accessions": len(accessions),
+            "failed": failed,
             **counts,
         },
     )
-    return {"key": key, "skipped": False, **counts}
+    return {"key": key, "skipped": False, "failed": failed, **counts}
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +359,7 @@ def fetch_rna_seq_counts() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Flows
+# Source + entry points
 # ---------------------------------------------------------------------------
 
 
@@ -319,16 +405,13 @@ class GeoSource:
         return SemaphoreStore("geo").pending_keys(months, always=always, force=force)
 
 
-@flow(
-    name="geo-extract",
-    task_runner=ProcessPoolTaskRunner(max_workers=2),
-)
-def geo_extract_flow(
+def geo_extract(
     start_month: str = "2005-01",
     end_month: str | None = None,
     rerun_current_month: bool = True,
     force: bool = False,
-) -> None:
+    max_workers: int = MAX_WORKERS,
+) -> list[dict]:
     """Extract GEO metadata, one monthly partition at a time.
 
     By default iterates from ``start_month`` to the current month, skipping
@@ -336,21 +419,57 @@ def geo_extract_flow(
     everything in the range. Set ``rerun_current_month=False`` to also
     skip the current month if its semaphore exists.
     """
-    run_extraction(
+    return run_extraction(
         GeoSource(
             start_month=start_month,
             end_month=end_month,
             rerun_current_month=rerun_current_month,
         ),
         force=force,
+        max_workers=max_workers,
     )
 
 
 @flow(name="geo-rna-seq-counts")
 def geo_rna_seq_counts_flow() -> None:
-    """Refresh the (small) GSE-with-RNA-seq-counts file. Not partitioned."""
+    """Refresh the (small) GSE-with-RNA-seq-counts file. Not partitioned.
+
+    Still a Prefect flow: it is not part of the extract and stays in
+    `raw_extract_flow` until the downstream unit (#158) replaces it.
+    """
     fetch_rna_seq_counts()
 
 
+@click.group()
+def cli() -> None:
+    """GEO raw extraction (`python -m omicidx.prefect.flows.geo run`)."""
+
+
+@cli.command("run")
+@click.option("--start-month", default="2005-01", show_default=True)
+@click.option("--end-month", default=None, help="Defaults to the current month.")
+@click.option("--force", is_flag=True, help="Re-extract every month in the range.")
+@click.option("--max-workers", default=MAX_WORKERS, show_default=True)
+def run_command(
+    start_month: str, end_month: str | None, force: bool, max_workers: int
+) -> None:
+    """Extract every pending GEO monthly partition."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    results = geo_extract(
+        start_month=start_month,
+        end_month=end_month,
+        force=force,
+        max_workers=max_workers,
+    )
+    extracted = [r for r in results if not r.get("skipped")]
+    rows = sum(r.get("GSE", 0) + r.get("GSM", 0) + r.get("GPL", 0) for r in extracted)
+    click.echo(
+        f"geo: {len(extracted)} months extracted "
+        f"({len(results) - len(extracted)} skipped), {rows:,} records"
+    )
+
+
 if __name__ == "__main__":
-    geo_extract_flow()
+    cli()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -454,9 +454,21 @@ def run_command(
     start_month: str, end_month: str | None, force: bool, max_workers: int
 ) -> None:
     """Extract every pending GEO monthly partition."""
+    # force=True is load-bearing, not cargo cult. This module still imports
+    # `prefect` for `geo_rna_seq_counts_flow`, and that import installs a
+    # PrefectConsoleHandler on the *root* logger at level WARNING -- which makes
+    # a plain `basicConfig()` a silent no-op and drops every INFO line this
+    # process emits. Caught only by running the entry point: a month extracted
+    # correctly and logged absolutely nothing to journald. Drop the `force` when
+    # geo_rna_seq_counts_flow leaves (#158) and the prefect import goes.
     logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
     )
+    # httpx logs one INFO line per request; a month is ~62k requests, so at
+    # INFO this unit alone would write ~5M lines/night into journald.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     results = geo_extract(
         start_month=start_month,
         end_month=end_month,

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -42,12 +42,12 @@ def raw_extract_flow(force: bool = False) -> None:
     # EL process (#153) and now runs on its own systemd timer
     # (`systemd/omicidx-sra-extract.timer`); ad-hoc runs are
     # `python -m omicidx.prefect.flows.sra run` or `omicidx-prefect run sra`.
-    # ponytail: geo-extract is deliberately absent. It wedges on 2020-07 and
-    # held the whole pipeline in `Running` from 2026-08-08, so every stage
-    # below it — including the publish — has not run for a month. Four healthy
-    # domains flowing beats five domains blocked. GEO returns as its own
-    # scheduled EL process (#154), not here; ad-hoc runs still work via the
-    # `geo-extract` deployment and `omicidx-prefect run geo-extract`.
+    # ponytail: geo-extract is deliberately absent. It now runs on its own
+    # systemd timer (`systemd/omicidx-geo-extract.timer`, #154) — stacked
+    # concurrent runs of it were what held this pipeline in `Running` from
+    # 2026-08-08. Ad-hoc runs are `python -m omicidx.prefect.flows.geo run`
+    # or `omicidx-prefect run geo`. `geo_rna_seq_counts_flow` below is a
+    # separate, non-partitioned refresh and is not part of that migration.
     # ponytail: ebi-biosample-extract is deliberately absent. It now runs on its
     # own systemd timer (`systemd/omicidx-ebi-biosample-extract.timer`, daily
     # 02:00 UTC); ad-hoc runs are

--- a/packages/omicidx-prefect/tests/test_geo.py
+++ b/packages/omicidx-prefect/tests/test_geo.py
@@ -1,0 +1,68 @@
+"""Guards for the GEO EL process (#154).
+
+The 2020-07 "hang" was throughput collapse under stacked concurrent runs, not
+a code fault — but the reason nobody could see that is that every per-accession
+failure vanished into `return_exceptions=True` and a month that ground for 20
+hours looked identical to a month that was working. These two tests cover the
+guards that make both loud.
+"""
+
+import asyncio
+
+import pytest
+
+
+def _stub_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("PUBLISH_ROOT", str(tmp_path))
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "x")
+    monkeypatch.setenv("S3_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv("S3_REGION", "auto")
+    from omicidx.prefect import config
+
+    config.settings.cache_clear()
+
+
+def test_fetch_and_parse_counts_failures(monkeypatch, tmp_path):
+    """Per-accession failures are counted and returned, not swallowed."""
+    _stub_env(monkeypatch, tmp_path)
+    from omicidx.prefect.flows import geo
+
+    async def fake_fetch(acc, client):
+        if acc.endswith("3"):
+            raise RuntimeError("boom")
+        return f"^SERIES = {acc}\n!Series_title = t\n"
+
+    monkeypatch.setattr(geo, "_fetch_soft", fake_fetch)
+    accessions = [f"GSE{i}" for i in range(10)]
+
+    _, failed = asyncio.run(geo._fetch_and_parse(accessions, concurrency=2))
+
+    assert failed == 1  # GSE3
+
+
+def test_extract_month_refuses_to_mark_a_holed_month_done(monkeypatch, tmp_path):
+    """Too many fetch failures -> raise, and leave no semaphore behind."""
+    _stub_env(monkeypatch, tmp_path)
+    from omicidx.prefect.flows import geo
+    from omicidx.prefect.semaphore import SemaphoreStore
+
+    accessions = [f"GSE{i}" for i in range(100)]
+    monkeypatch.setattr(
+        geo, "_fetch_accessions", lambda start, end: _completed(accessions)
+    )
+    monkeypatch.setattr(
+        geo,
+        "_fetch_and_parse",
+        lambda accs, **kw: _completed(({"GSE": [], "GSM": [], "GPL": []}, 50)),
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to mark the month done"):
+        geo.extract_month("2020-07")
+
+    assert not SemaphoreStore("geo").exists("2020-07")
+
+
+async def _completed(value):
+    """`extract_month` calls these under `asyncio.run`, so stubs stay awaitable."""
+    return value

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -10,6 +10,7 @@ deployment artifacts. Convention (and the rationale for every field) lives in
 | `omicidx-sra-extract` | `python -m omicidx.prefect.flows.sra run` | daily 01:00 UTC (+≤30m jitter) |
 | `omicidx-ebi-biosample-extract` | `python -m omicidx.prefect.flows.ebi_biosample run` | daily 02:00 UTC (+≤30m jitter) |
 | `omicidx-biosample-extract` | `python -m omicidx.prefect.flows.biosample run` | daily 04:00 UTC (+≤30m jitter) |
+| `omicidx-geo-extract` | `python -m omicidx.prefect.flows.geo run` | daily 06:00 UTC (+≤30m jitter) |
 | `omicidx-pubmed-extract` | `python -m omicidx.prefect.flows.pubmed run` | hourly (+≤5m jitter) |
 
 `omicidx-biosample-extract` covers **both** NCBI full dumps (BioSample and
@@ -24,6 +25,12 @@ BioSample it had no Prefect deployment of its own — it only ran inside
 `daily-pipeline` — so removing it from `raw_extract_flow` was the whole cutover;
 nothing to delete API-side.
 
+`omicidx-geo-extract` also declares no `Conflicts=`, for the same reason: it is
+bandwidth-light (tens of thousands of small `acc.cgi` requests, <1 GB RSS). The
+only thing GEO cannot tolerate is another copy of *itself* on the same NCBI
+endpoint — that is exactly what wedged it (#154) — and `Type=oneshot` already
+guarantees one instance.
+
 `ntfy-notify@.service` and `notify-failure.sh` are **not** duplicated here — the
 shared template installed from `cdsci-lake/systemd/` is what every
 `OnFailure=ntfy-notify@%N.service` in this directory resolves to, and one topic
@@ -36,6 +43,7 @@ failed"; the failing unit name in the body is what identifies it.
 cp systemd/omicidx-sra-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-ebi-biosample-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-biosample-extract.{service,timer} ~/.config/systemd/user/
+cp systemd/omicidx-geo-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-pubmed-extract.{service,timer} ~/.config/systemd/user/
 # once, shared, if not already present:
 cp ~/Documents/git/cdsci-lake/systemd/ntfy-notify@.service ~/.config/systemd/user/
@@ -43,13 +51,14 @@ systemctl --user daemon-reload
 systemctl --user enable --now omicidx-sra-extract.timer
 systemctl --user enable --now omicidx-ebi-biosample-extract.timer
 systemctl --user enable --now omicidx-biosample-extract.timer
+systemctl --user enable --now omicidx-geo-extract.timer
 systemctl --user enable --now omicidx-pubmed-extract.timer
 ```
 
 Verify (substitute the unit you just installed):
 
 ```bash
-systemctl --user list-timers omicidx-biosample-extract.timer
+systemctl --user list-timers 'omicidx-*'
 systemctl --user start omicidx-biosample-extract.service   # one run by hand
 journalctl --user -u omicidx-biosample-extract.service -f
 ```
@@ -89,6 +98,24 @@ Extraction leaves no `lake_ops.run` row by design (#149): it writes raw files to
 R2 and adds no DuckLake snapshot, so the ledger is the per-partition semaphores
 (`omicidx-prefect semaphores list sra/study`, `... list biosample`), journald is
 the narrative, and ntfy is the failure signal. `ops.run` stays on the load side.
+
+## GEO: expect a backfill before it settles
+
+`omicidx-geo-extract` has 74 pending months when first installed — GEO has
+never gotten past `2020-07`. Each month is ~22 min, so the 6h `TimeoutStartSec`
+clears roughly 16 months a night and the run *will* hit that timeout (and fire
+an ntfy alert) for the first four or five nights. That is expected: semaphores
+make the next night resume where it stopped. Watch it drain with
+
+```bash
+omicidx-prefect semaphores list geo | head -1
+```
+
+To burn the backfill down faster, run it in the foreground with no deadline:
+
+```bash
+uv run python -m omicidx.prefect.flows.geo run   # resumable; ^C is safe
+```
 
 Copy, don't symlink: symlinked units go dangling when a repo moves, and systemd
 then fails to load them silently (this is exactly how `omicidx-sql-runner` died).

--- a/systemd/omicidx-geo-extract.service
+++ b/systemd/omicidx-geo-extract.service
@@ -1,0 +1,39 @@
+# GEO monthly EL process (#154). Follows the pilot pattern set by
+# omicidx-sra-extract.service (#153); convention is monode/infrastructure's
+# SCHEDULING.md.
+#
+# The module path still says `prefect` and no Prefect is involved: the rename
+# is #160, which has to touch every unit file anyway.
+[Unit]
+Description=Extract GEO metadata (monthly partitions) to raw NDJSON on R2
+Documentation=https://github.com/seandavi/omicidx/issues/154
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+# Deliberately NO Conflicts=. GEO is not bandwidth-heavy like sra/biosample
+# (it is tens of thousands of small acc.cgi requests, ~0.2 GB RSS); what it
+# cannot tolerate is *another copy of itself* on the same NCBI endpoint, and
+# Type=oneshot + systemd already guarantees one instance of this unit.
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/omicidx
+EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
+# NOT `/usr/bin/env uv` — systemd --user gives a minimal PATH that excludes
+# ~/.local/bin, so `env uv` exits 127. `systemd-analyze verify` does not catch
+# it; only starting the unit does. See #153 / commit 9c4680a.
+ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.geo run
+# RuntimeMaxSec= silently has no effect on Type=oneshot — use TimeoutStartSec=.
+#
+# Sizing, from measurement rather than guesswork (#154): one month is one
+# acc.cgi request per accession, ~62k for a 2020 month, and a single process
+# sustains ~43 req/s => ~22 min/month. An incremental night is one month (the
+# current one). But 74 months are still pending — GEO has never gotten past
+# 2020-07 — so the first nights are a backfill: 6h clears ~16 months, and
+# semaphores make the next night resume exactly where this one stopped. Five
+# or six nights to catch up, then it is a 20-minute job forever.
+TimeoutStartSec=21600
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/omicidx-geo-extract.timer
+++ b/systemd/omicidx-geo-extract.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily GEO metadata extraction (cadence preserved from daily-pipeline)
+
+[Timer]
+# 06:00 UTC, the slot #153 allocated GEO (sra 01:00, ebi_biosample 02:00,
+# biosample 04:00, geo 06:00; pubmed stays hourly). The host is
+# America/Denver, so UTC is stated explicitly.
+OnCalendar=*-*-* 06:00:00 UTC
+RandomizedDelaySec=1800
+# A missed night catches up on next boot. Cheap once the backfill is done:
+# every month with a semaphore is skipped, leaving only the current month.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Applies the #153 pattern to GEO and closes out the one genuinely unknown fault on map #144.

## The diagnosis: 2020-07 never hung

**It is not a bug in the extractor.** Measured single-process against live NCBI (while a live prod `geo-extract` run was competing for the same endpoint): all **62,419 accessions of 2020-07 in ~22 minutes at ~44 req/s, 0.2 GB RSS, zero errors**.

Ruled out with evidence, not vibes:

| Hypothesis | Verdict |
|---|---|
| Missing HTTP timeout (`timeout=None`) | **Out.** Both clients pass explicit timeouts (`AsyncClient(timeout=60)` for eutils, `timeout=30` for acc.cgi). No un-timed-out socket read exists in `geo.py`. |
| Pagination cliff at ~62k | **Out.** `esearch` `retstart` paginates cleanly through 62,419 (probed 0 / 5000 / 9990 / 10000 / 20000 / 60000 — all HTTP 200, correct id counts, no `ERROR`). |
| Memory cliff | **Out.** Peak RSS 0.35 GB fetching the whole month. |
| **Stacked concurrent runs throttling NCBI** | **In. This is it.** |

What ran in prod was up to 13 stacked `geo-extract` flow runs x `ProcessPoolTaskRunner(max_workers=2)` x 30-way asyncio fan-out = **up to 780 concurrent requests at one NCBI endpoint**. NCBI degrades hard past the knee — measured from a cold client on the same 300 accessions:

- **8-wide** → 61 req/s, 0 errors, p95 0.22s
- **30-wide** → 6.5 req/s, **10% of requests hit the 30s read timeout**, p95 30s

The semaphore ledger is the receipt. GEO's last five completed months landed **13.7–22.7 hours apart**:

```
2020-01  2026-08-11T23:13Z
2020-03  2026-08-12T18:54Z
2020-04  2026-08-13T08:39Z   (+13.7h)
2020-05  2026-08-13T22:20Z   (+13.7h)
2020-06  2026-08-14T21:05Z   (+22.7h)
```

~62k accessions per month over ~14-23h is **~1.2 req/s** — a 35x collapse from the 44 req/s a single process gets. No month ever finished inside a run's lifetime, so no semaphore was written, so the next stacked run redid the same month: **9 starts of 2020-07, 27 rewrites of 2020-06** (27 = 9 runs x `@task(retries=2)`).

And the deeper finding: **2020-07 is not special, it is just the frontier.** 74 consecutive months (2020-07 through 2026-08) have never been extracted. GEO has been crawling a six-year backlog at one month per waking day.

## The fix

The shape of the run, not the extractor:

- `MAX_WORKERS = 1` — one month at a time. Unlike SRA a GEO partition is not one file; it is already fanned 30-wide internally. A second month buys no parallelism, only double load on the endpoint that wedged.
- `MONTH_FETCH_CONCURRENCY = 30` unchanged (measured clean single-process).

Plus three guards so the next one is loud instead of silent:

- **per-month `asyncio.timeout` deadline** (2h vs 22 min measured). Every socket already has a timeout so nothing blocks forever — but "62k requests at 1.2/s" is indistinguishable from a hang from outside. Now it crashes and trips `OnFailure=`.
- **fetch failures are counted, not swallowed.** `return_exceptions=True` was discarding them: 2020-06 was marked *done* having written 68,296 of 73,548 GSMs — a **7% hole under a green semaphore**. Failures now land in the semaphore metadata, and a month losing >2% refuses to mark itself done.
- **`_fetch_soft` gets the retry predicate `_fetch_accessions` already had**, so a 404 no longer burns 5 exponentially-backed-off attempts.

## Mechanical migration (#153 checklist)

1-4. `@flow`/`@task`/`ProcessPoolTaskRunner`/`get_run_logger` stripped from the extract path; module-level stdlib `log`; `geo_extract_flow` → `geo_extract(..., max_workers=MAX_WORKERS)`; click `run` group; `cli.py` import fixed.
5. GEO was already out of `raw_extract_flow` (#162 / `5a11b08`) — comment updated to point at the timer.
6. `systemd/omicidx-geo-extract.{service,timer}` at **06:00 UTC** (the slot #153 allocated), `%h/.local/bin/uv` form, `TimeoutStartSec=21600`, README updated.
7. Semaphores untouched.

`geo_rna_seq_counts_flow` is a separate non-partitioned refresh and **stays** in `raw_extract_flow` (keeps its Prefect decorators) until #158.

**The `prefect.yaml` `geo-extract` deployment is removed.** Its entrypoint symbol `geo_extract_flow` no longer exists, so it would be a broken deployment; it carried no schedule, so nothing needs unregistering through the API (unlike pubmed in #157); and stacked *manual* runs of that very deployment are what wedged the pipeline. Ad-hoc is `omicidx-prefect run geo` / `python -m omicidx.prefect.flows.geo run`.

## Installing this

Not done here — a live-system change. `systemd/README.md` has the commands, plus a heads-up that the **74-month backfill (~27h)** should be burned down in the foreground once rather than letting the timer hit `TimeoutStartSec` and alert for five straight nights.

Refs #154, #149, #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY
