### PR TITLE
feat(ebi-biosample): run EBI BioSample extraction as a standalone scheduled EL process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ raw-extract → ducklake-load → transform → parquet-export → postgres-load
 `flows/biosample.py` followed (#155) — one unit for **both** NCBI full dumps
 (BioSample + BioProject), `systemd/omicidx-biosample-extract.timer`; being
 unpartitioned, it calls its extracts directly instead of via `run_extraction`.
+`flows/pubmed.py` (#157, hourly) and `flows/ebi_biosample.py` (#156, daily 02:00
+UTC) followed the same way, both still fanning out through `run_extraction`.
 The shared driver `source.py` is orchestrator-neutral (bounded
 `ThreadPoolExecutor` + tenacity), so any domain not yet migrated keeps working
 unchanged until its own ticket (#154–#157) strips its decorators too.

--- a/packages/omicidx-prefect/src/omicidx/prefect/cli.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/cli.py
@@ -111,9 +111,9 @@ def run_pubmed(force: bool) -> None:
 @click.option("--end-day", default=None)
 @click.option("--force", is_flag=True)
 def run_ebi_biosample(start_day: str, end_day: str | None, force: bool) -> None:
-    from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
+    from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract
 
-    ebi_biosample_extract_flow(start_day=start_day, end_day=end_day, force=force)
+    ebi_biosample_extract(start_day=start_day, end_day=end_day, force=force)
 
 
 @run.command("consolidate")

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/ebi_biosample.py
@@ -1,19 +1,27 @@
-"""EBI Biosample extract flow.
+"""EBI BioSample extract: a standalone scheduled EL process (#156, following #153).
 
 Partitions are calendar days (YYYY-MM-DD), starting at 2021-01-01. Each
 day gets a semaphore at `_semaphores/ebi_biosample/{YYYY-MM-DD}.json`,
 including empty days (legitimately many days have zero updates). The
-flow defaults to enumerating from the start date to today, processing
+extractor defaults to enumerating from the start date to today, processing
 only missing-semaphore days. The current day is always re-run.
+
+No orchestrator: run it as `python -m omicidx.prefect.flows.ebi_biosample run`
+(that is what `systemd/omicidx-ebi-biosample-extract.service` does), logs go to
+stdout -> journald, failures trip `OnFailure=ntfy-notify@%N.service`, and the
+semaphores are the per-partition ledger. The module path still says `prefect`
+only because the rename is #160.
 """
 
 import asyncio
 import gzip
+import logging
 import shutil
 import tempfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
+import click
 import httpx
 import orjson
 import tenacity
@@ -21,12 +29,17 @@ from omicidx.prefect.config import get_duckdb_connection, get_duckdb_path, get_u
 from omicidx.prefect.semaphore import SemaphoreStore
 from omicidx.prefect.source import run_extraction
 
-from prefect import flow, get_run_logger, task
-from prefect.task_runners import ThreadPoolTaskRunner
+log = logging.getLogger(__name__)
 
 EBI_BIOSAMPLES_BASE_URL = "https://www.ebi.ac.uk/biosamples/samples"
 EBI_PAGE_SIZE = 200
 EBI_REQUEST_TIMEOUT = 40.0
+
+#: Concurrent calendar days in flight. Was `ThreadPoolTaskRunner(max_workers=4)`
+#: — already threads, so this is a like-for-like swap onto the shared driver's
+#: pool: mechanism changed, load on the EBI BioSamples API unchanged. Each day
+#: is a cursor-paged HTTP crawl, i.e. IO-bound, so threads are the right pool.
+MAX_WORKERS = 4
 
 
 def _partition_filename(partition_date: date) -> str:
@@ -97,18 +110,14 @@ class _SampleFetcher:
         return count
 
 
-@task(
-    retries=2,
-    retry_delay_seconds=30,
-    task_run_name="ebi-biosample-extract-{key}",
-)
 def extract_ebi_biosample(key: str, force: bool = False) -> dict:
     """Extract one calendar-day partition of EBI BioSamples.
 
     The current day always re-extracts (updates accrue through the day); a past
-    day with a semaphore is skipped unless ``force``.
+    day with a semaphore is skipped unless ``force``. Retries are the driver's
+    (`run_extraction`), not this function's; the per-page HTTP retry below is
+    separate and stays.
     """
-    log = get_run_logger()
     sem = SemaphoreStore("ebi_biosample")
     # "Current day is volatile" is defined in two paired places: Ebi
     # BiosampleSource.list_partitions keeps it pending (always=[current]); this
@@ -174,10 +183,17 @@ def _enumerate_days(start: str = "2021-01-01", end: str | None = None) -> list[s
     return keys
 
 
-@task(retries=1, retry_delay_seconds=60)
 def consolidate_ebi_biosample_parquet() -> dict:
-    """Consolidate per-day NDJSON into a single parquet via DuckDB."""
-    log = get_run_logger()
+    """Consolidate per-day NDJSON into a single parquet via DuckDB.
+
+    ponytail: kept because removing it would change behaviour, not because
+    anything reads it — `ducklake_ebi_biosample.py` MERGEs from the raw NDJSON
+    glob, and the public `ebi_biosample.parquet` comes out of `parquet_export`
+    from the lake. Nothing in this repo consumes
+    `ebi_biosample/parquet/ebi_biosamples.parquet`. If that holds after #158
+    audits the downstream unit, delete this and pass `--no-consolidate` becomes
+    moot.
+    """
     input_glob = get_duckdb_path("ebi_biosample", "raw", "biosamples-*.ndjson.gz")
     output_path = get_duckdb_path("ebi_biosample", "parquet", "ebi_biosamples.parquet")
     sql = f"""
@@ -230,29 +246,67 @@ class EbiBiosampleSource:
         )
 
 
-@flow(
-    name="ebi-biosample-extract",
-    task_runner=ThreadPoolTaskRunner(max_workers=4),
-)
-def ebi_biosample_extract_flow(
+def ebi_biosample_extract(
     start_day: str = "2021-01-01",
     end_day: str | None = None,
     rerun_current_day: bool = True,
     force: bool = False,
     consolidate: bool = True,
-) -> None:
-    run_extraction(
+    max_workers: int = MAX_WORKERS,
+) -> list[dict]:
+    """Extract every calendar day whose semaphore is missing, plus today."""
+    results = run_extraction(
         EbiBiosampleSource(
             start_day=start_day,
             end_day=end_day,
             rerun_current_day=rerun_current_day,
         ),
         force=force,
+        max_workers=max_workers,
     )
 
     if consolidate:
         consolidate_ebi_biosample_parquet()
 
+    return results
+
+
+@click.group()
+def cli() -> None:
+    """EBI BioSample raw extraction (`python -m omicidx.prefect.flows.ebi_biosample run`)."""
+
+
+@cli.command("run")
+@click.option("--start-day", default="2021-01-01", show_default=True)
+@click.option("--end-day", default=None)
+@click.option("--force", is_flag=True, help="Re-extract every partition.")
+@click.option("--no-consolidate", is_flag=True, help="Skip the parquet rollup.")
+@click.option("--max-workers", default=MAX_WORKERS, show_default=True)
+def run_command(
+    start_day: str,
+    end_day: str | None,
+    force: bool,
+    no_consolidate: bool,
+    max_workers: int,
+) -> None:
+    """Extract every pending EBI BioSample day partition."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    results = ebi_biosample_extract(
+        start_day=start_day,
+        end_day=end_day,
+        force=force,
+        consolidate=not no_consolidate,
+        max_workers=max_workers,
+    )
+    extracted = [r for r in results if not r.get("skipped")]
+    rows = sum(r.get("row_count", 0) for r in extracted)
+    click.echo(
+        f"ebi_biosample: {len(extracted)} partitions extracted "
+        f"({len(results) - len(extracted)} skipped), {rows:,} rows"
+    )
+
 
 if __name__ == "__main__":
-    ebi_biosample_extract_flow()
+    cli()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/main.py
@@ -15,7 +15,6 @@ verified in prod.
 """
 
 from omicidx.prefect.flows.ducklake_load import ducklake_load_flow
-from omicidx.prefect.flows.ebi_biosample import ebi_biosample_extract_flow
 from omicidx.prefect.flows.geo import geo_rna_seq_counts_flow
 from omicidx.prefect.flows.parquet_export import parquet_export_flow
 from omicidx.prefect.flows.postgres import postgres_load_flow
@@ -49,8 +48,14 @@ def raw_extract_flow(force: bool = False) -> None:
     # domains flowing beats five domains blocked. GEO returns as its own
     # scheduled EL process (#154), not here; ad-hoc runs still work via the
     # `geo-extract` deployment and `omicidx-prefect run geo-extract`.
+    # ponytail: ebi-biosample-extract is deliberately absent. It now runs on its
+    # own systemd timer (`systemd/omicidx-ebi-biosample-extract.timer`, daily
+    # 02:00 UTC); ad-hoc runs are
+    # `python -m omicidx.prefect.flows.ebi_biosample run` or
+    # `omicidx-prefect run ebi-biosample`. With it goes the last *extract*:
+    # `geo_rna_seq_counts_flow` below is a derived flow, not an extract, so
+    # where it belongs is #158's call, not this ticket's.
     geo_rna_seq_counts_flow()
-    ebi_biosample_extract_flow(force=force)
     # ponytail: pubmed-extract is deliberately absent. It now runs on its own
     # systemd timer (`systemd/omicidx-pubmed-extract.timer`, hourly, the cadence
     # its retired `pubmed-extract` deployment had); ad-hoc runs are

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -8,6 +8,7 @@ deployment artifacts. Convention (and the rationale for every field) lives in
 | Unit | Runs | Cadence |
 |---|---|---|
 | `omicidx-sra-extract` | `python -m omicidx.prefect.flows.sra run` | daily 01:00 UTC (+≤30m jitter) |
+| `omicidx-ebi-biosample-extract` | `python -m omicidx.prefect.flows.ebi_biosample run` | daily 02:00 UTC (+≤30m jitter) |
 | `omicidx-biosample-extract` | `python -m omicidx.prefect.flows.biosample run` | daily 04:00 UTC (+≤30m jitter) |
 | `omicidx-pubmed-extract` | `python -m omicidx.prefect.flows.pubmed run` | hourly (+≤5m jitter) |
 
@@ -15,6 +16,13 @@ deployment artifacts. Convention (and the rationale for every field) lives in
 BioProject) in one unit: same machinery, two URLs, both unpartitioned. It and
 `omicidx-sra-extract` are the two heavy jobs and `Conflicts=` each other — which
 *stops* the loser rather than queueing it, hence the three-hour gap.
+
+`omicidx-ebi-biosample-extract` declares no `Conflicts=` and sits between them:
+it crawls the EBI BioSamples HTTP API rather than pulling an NCBI bulk file, so
+it does not contend for the bandwidth the two heavy jobs fight over. Like SRA and
+BioSample it had no Prefect deployment of its own — it only ran inside
+`daily-pipeline` — so removing it from `raw_extract_flow` was the whole cutover;
+nothing to delete API-side.
 
 `ntfy-notify@.service` and `notify-failure.sh` are **not** duplicated here — the
 shared template installed from `cdsci-lake/systemd/` is what every
@@ -26,12 +34,14 @@ failed"; the failing unit name in the body is what identifies it.
 
 ```bash
 cp systemd/omicidx-sra-extract.{service,timer} ~/.config/systemd/user/
+cp systemd/omicidx-ebi-biosample-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-biosample-extract.{service,timer} ~/.config/systemd/user/
 cp systemd/omicidx-pubmed-extract.{service,timer} ~/.config/systemd/user/
 # once, shared, if not already present:
 cp ~/Documents/git/cdsci-lake/systemd/ntfy-notify@.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now omicidx-sra-extract.timer
+systemctl --user enable --now omicidx-ebi-biosample-extract.timer
 systemctl --user enable --now omicidx-biosample-extract.timer
 systemctl --user enable --now omicidx-pubmed-extract.timer
 ```

--- a/systemd/omicidx-ebi-biosample-extract.service
+++ b/systemd/omicidx-ebi-biosample-extract.service
@@ -1,0 +1,37 @@
+# EBI BioSamples as a standalone scheduled EL process (#156), following the
+# pilot in omicidx-sra-extract.service (#153). Convention:
+# monode/infrastructure's SCHEDULING.md.
+#
+# The module path still says `prefect` and no Prefect is involved: the rename
+# is #160, which has to touch every unit file anyway.
+#
+# No Conflicts=: this is a cursor-paged HTTPS crawl of the EBI BioSamples API,
+# not an NCBI bulk download, so it contends with neither omicidx-sra-extract nor
+# omicidx-biosample-extract for the bandwidth those two fight over. It also sits
+# between them (02:00) precisely because it is the light one.
+[Unit]
+Description=Extract EBI BioSamples day partitions to raw NDJSON on R2
+Documentation=https://github.com/seandavi/omicidx/issues/156
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/omicidx
+EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
+# NOT `/usr/bin/env uv` — systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127. `systemd-analyze verify` does NOT
+# catch it — only actually starting the unit does (#153).
+ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.ebi_biosample run
+# RuntimeMaxSec= silently has no effect on Type=oneshot — use TimeoutStartSec=.
+# An incremental night is one day partition (seconds) plus the DuckDB rollup over
+# ~2,000 NDJSON files (minutes). 6h is sized for a backfill night, where every
+# missing day since 2021-01-01 is crawled 4-wide; per-day semaphores make a
+# timeout resumable rather than wasted.
+TimeoutStartSec=21600
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/omicidx-ebi-biosample-extract.timer
+++ b/systemd/omicidx-ebi-biosample-extract.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily EBI BioSamples extraction (cadence preserved from daily-pipeline)
+
+[Timer]
+# Daily, the cadence daily-pipeline already ran at — #149 decided to change the
+# mechanism, not the rate. 02:00 is this domain's slot in the #153 staggering
+# (sra 01:00, ebi_biosample 02:00, biosample 04:00, geo 06:00; pubmed hourly).
+# The host is America/Denver, so UTC is explicit.
+OnCalendar=*-*-* 02:00:00 UTC
+RandomizedDelaySec=1800
+# A missed night (box off) catches up on next boot. Cheap if today's run already
+# succeeded: past days short-circuit on their semaphores, leaving only the
+# always-rerun current day.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the last of the five domain migrations under #149. Resolves #156.

Mechanical, per the #153 checklist — decorators stripped, stdlib logging, click
`run` group, removed from `raw_extract_flow`, unit files added.

## Task-runner call

`MAX_WORKERS = 4`, preserved verbatim from `ThreadPoolTaskRunner(max_workers=4)`.
Unlike PubMed (which was a `ProcessPoolTaskRunner` and silently became threads),
this domain was **already** on a thread pool, so moving onto the shared drivers
`ThreadPoolExecutor` is like-for-like: no pool-type change to declare, and each
day partition is a cursor-paged HTTPS crawl, i.e. IO-bound, so threads are the
right pool anyway.

## No Prefect deployment

Like SRA and BioSample, `ebi-biosample` had no `prefect.yaml` deployment — it
only ran inside `daily-pipeline`. Removing it from `raw_extract_flow` is the
whole cutover; nothing to delete API-side.

## Unit

`systemd/omicidx-ebi-biosample-extract.{service,timer}` — daily **02:00 UTC**
(its slot in the #153 staggering), `RandomizedDelaySec=1800`,
`TimeoutStartSec=21600`, `Nice=10`, `OnFailure=ntfy-notify@%N.service`,
`ExecStart=%h/.local/bin/uv run ...`. **No `Conflicts=`** — this crawls the EBI
BioSamples HTTP API rather than pulling an NCBI bulk file, so it does not contend
with `omicidx-sra-extract` / `omicidx-biosample-extract` for the bandwidth those
two fight over.

## Proven to start

`systemd-run --user` against this branch (not the main checkout):

```
ebi_biosample: 1 partitions pending extraction (max_workers=4)
Fetching EBI biosamples for 2026-08-14
Wrote 54 records to s3://omicidx/ebi_biosample/raw/biosamples-2026-08-14.ndjson.gz
ebi_biosample: 1 partitions extracted (0 skipped), 54 rows
Finished with result: success / code=exited/status=0
```

## Out of scope, flagged

- The `Could not resolve hostname` failures the ticket describes are **load-side**
  (`flows/ducklake_ebi_biosample.py`), not extract-side. Not touched here. But
  the URLs in them point at `omicidx-test`, and both the current worker container
  and the host `.env` now use `PUBLISH_ROOT=r2://omicidx` — so that looks like a
  stale-bucket artifact of the pre-rebuild container rather than intermittent
  DNS. Belongs in #158 or its own ticket.
- `r2://omicidx` currently has **no** `ebi_biosample/` prefix and **zero**
  `_semaphores/ebi_biosample/` keys, so the first timer fire will backfill all
  ~2,052 days. `TimeoutStartSec` is sized for that and per-day semaphores make a
  timeout resumable rather than wasted.
- `consolidate_ebi_biosample_parquet` is kept (behaviour preserved) but has **no
  in-repo consumer** — `ducklake_ebi_biosample.py` MERGEs from the raw NDJSON
  glob and the public `ebi_biosample.parquet` comes from `parquet_export`. Marked
  with a `ponytail:` comment for #158 to delete.
- After this merge `raw_extract_flow` holds only `geo_rna_seq_counts_flow`, a
  derived flow rather than an extract. Deliberately **not** moved — #158s call.

## Install (not done by CI)

```bash
cp systemd/omicidx-ebi-biosample-extract.{service,timer} ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now omicidx-ebi-biosample-extract.timer
systemctl --user start omicidx-ebi-biosample-extract.service   # one run by hand
journalctl --user -u omicidx-ebi-biosample-extract.service -f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY