### PR TITLE
feat(geo): audit completeness via eutils counts + scale the month deadline (#174)

### DIFF
--- a/packages/omicidx-prefect/scripts/geo_audit.py
+++ b/packages/omicidx-prefect/scripts/geo_audit.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Audit GEO month completeness against eutils counts — without fetching records.
+
+READ-ONLY. Answers the open question in #174 ("how to detect it") for a few
+hundred requests instead of a re-crawl.
+
+`esearch` returns `esearchresult.count` for a query while returning zero
+records, so one request per month says how many accessions GEO holds in that
+month's Update Date window. What we wrote is already in the month's semaphore
+metadata (`{"GSE": .., "GSM": .., "GPL": ..}`). Comparing the two costs ~185
+tiny requests; re-extracting to find out costs ~68 hours.
+
+**The comparison is one-sided, and that is what makes it sound.** Partitions are
+keyed by Update Date, and an update date only moves forward: a record extracted
+into 2008-06 that was touched again in 2024 has since left the 2008-06 window.
+So today's count can only be <= the count at extraction time. `written < today`
+is therefore proof of a hole, and the deficit is a lower bound. `written >=
+today` is not proof of health — it just isn't proof of loss.
+
+Compare like with like: the written figure sums GSE+GSM+GPL, so the query must
+not be restricted by `[etyp]`. (#174's headline "68,296 of 73,548" compared
+GSM-only writes against the all-entity count and so overstated 2020-06's loss
+as 7%; measured like-for-like it is 4.7%.)
+
+Usage (safe to run while an extract is in flight — see SLEEP):
+
+    uv run python packages/omicidx-prefect/scripts/geo_audit.py
+"""
+
+import sys
+import time
+from datetime import datetime
+
+import httpx
+from omicidx.prefect.flows.geo import _month_range
+from omicidx.prefect.semaphore import SemaphoreStore
+
+EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+
+#: Serial, and well under the 3 req/s anonymous eutils limit. This audit must
+#: never become the thing that throttles a running extract — hammering one NCBI
+#: endpoint is the whole subject of #154.
+SLEEP = 0.5
+
+
+def geo_count(client: httpx.Client, key: str) -> int:
+    """How many GEO accessions currently fall in month `key`'s update window."""
+    start, end = _month_range(datetime.strptime(key, "%Y-%m").date())
+    r = client.get(
+        EUTILS,
+        params={
+            "db": "gds",
+            "term": (
+                "(GSM[etyp] OR GSE[etyp] OR GPL[etyp]) AND "
+                f'("{start.strftime("%Y/%m/%d")}"[Update Date] : '
+                f'"{end.strftime("%Y/%m/%d")}"[Update Date])'
+            ),
+            "retmode": "json",
+            "retmax": 0,
+        },
+    )
+    r.raise_for_status()
+    return int(r.json()["esearchresult"]["count"])
+
+
+def main() -> None:
+    store = SemaphoreStore("geo")
+    keys = sorted(store.list_keys())
+    print(f"auditing {len(keys)} months with semaphores", file=sys.stderr)
+
+    short: list[tuple[str, int, int, int, float]] = []
+    ok = 0
+    no_counts: list[str] = []
+
+    with httpx.Client(timeout=60) as client:
+        for i, key in enumerate(keys, 1):
+            meta = (store.read(key) or {}).get("metadata") or {}
+            written = sum(meta.get(e, 0) for e in ("GSE", "GSM", "GPL"))
+            if not written:
+                # Pre-2005-05 semaphores predate the counts-in-metadata format.
+                no_counts.append(key)
+                continue
+            try:
+                have = geo_count(client, key)
+            except Exception as e:
+                print(f"{key}: eutils error {type(e).__name__}", file=sys.stderr)
+                continue
+            deficit = have - written
+            if deficit > 0:
+                short.append((key, written, have, deficit, deficit / have))
+                print(
+                    f"{key}: written {written:,} < geo {have:,} "
+                    f"-> missing >= {deficit:,} ({deficit / have:.1%})",
+                    flush=True,
+                )
+            else:
+                ok += 1
+            if i % 25 == 0:
+                print(f"  ...{i}/{len(keys)}", file=sys.stderr, flush=True)
+            time.sleep(SLEEP)
+
+    print(f"\n=== {len(short)} short, {ok} at-or-above, {len(no_counts)} no counts ===")
+    if short:
+        missing = sum(s[3] for s in short)
+        total = sum(s[2] for s in short)
+        print(
+            f"total missing across short months: {missing:,} of {total:,} "
+            f"({missing / total:.1%})"
+        )
+        print("\nworst by rate:")
+        for key, written, have, _, rate in sorted(short, key=lambda s: -s[4])[:15]:
+            print(f"  {key}  {written:>8,} / {have:>8,}   -{rate:.1%}")
+        print("\nre-extract list:")
+        print(" ".join(s[0] for s in sorted(short)))
+    if no_counts:
+        print(f"\nno usable counts in semaphore metadata: {' '.join(no_counts)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -73,11 +73,30 @@ MAX_WORKERS = 1
 #: the regime that produced the wedge -- it is the one knob that matters.
 MONTH_FETCH_CONCURRENCY = 30
 
-#: Wall-clock ceiling for one month's fetch. A full month measured 22 min, so
-#: this is ~5x headroom: a month that blows through it is pathological and
-#: should fail the process (and trip `OnFailure=`) rather than grind silently,
-#: which is exactly what nobody noticed for six years' worth of months.
-MONTH_TIMEOUT_SECONDS = 7200
+#: Floor for one month's fetch deadline. A month that blows through its deadline
+#: is pathological and should fail the process (and trip `OnFailure=`) rather
+#: than grind silently, which is exactly what nobody noticed for six years'
+#: worth of months. Small months finish in minutes, so the floor keeps the guard
+#: meaningful for them without tripping on ordinary variance.
+MONTH_TIMEOUT_FLOOR_SECONDS = 7200
+
+#: ...but the deadline is really a **rate** floor. A month's work is proportional
+#: to its accession count, so a fixed wall clock is only ever correct for one
+#: month size. Measured healthy throughput is ~44-47 req/s single-process, so
+#: 10 req/s preserves the ~5x headroom the original fixed 2h was chosen for, at
+#: any size.
+#:
+#: This is not hypothetical: **2019-05 holds 732,475 accessions** -- 16x its
+#: neighbours (2019-04: 46,106, 2019-06: 44,880), a GEO-wide bulk update -- and
+#: needs ~4.6h at measured rate. The fixed 2h killed it three times in a row,
+#: and being first in the pending list it blocked the entire 75-month backfill
+#: while extracting nothing (#174).
+MIN_FETCH_RATE = 10.0
+
+
+def month_deadline(n_accessions: int) -> float:
+    """Wall-clock ceiling for fetching `n_accessions`, expressed as a rate floor."""
+    return max(MONTH_TIMEOUT_FLOOR_SECONDS, n_accessions / MIN_FETCH_RATE)
 
 #: Fraction of a month's accessions that may fail to fetch before the month is
 #: not "done". Individual accessions do get withdrawn from GEO, so this is not
@@ -182,7 +201,7 @@ async def _fetch_soft(accession: str, client: httpx.AsyncClient) -> str:
 async def _fetch_and_parse(
     accessions: list[str],
     concurrency: int = MONTH_FETCH_CONCURRENCY,
-    timeout_seconds: int = MONTH_TIMEOUT_SECONDS,
+    timeout_seconds: float | None = None,
 ) -> tuple[dict[str, list[dict]], int]:
     """Fetch + parse every accession's SOFT record. Returns (records, n_failed).
 
@@ -193,6 +212,8 @@ async def _fetch_and_parse(
     results: dict[str, list[dict]] = {"GSE": [], "GSM": [], "GPL": []}
     semaphore = asyncio.Semaphore(concurrency)
     failed = 0
+    if timeout_seconds is None:
+        timeout_seconds = month_deadline(len(accessions))
 
     async def _one(acc: str, client: httpx.AsyncClient) -> None:
         nonlocal failed
@@ -214,6 +235,13 @@ async def _fetch_and_parse(
         # The deadline is the loud guard: every socket here already has a
         # timeout, so nothing blocks forever, but "62k requests at 1.2/s"
         # looks exactly like a hang from outside. This turns it into a crash.
+        log.info(
+            "geo: %d accessions, deadline %.1fh (floor %.1fh, min %.0f req/s)",
+            len(accessions),
+            timeout_seconds / 3600,
+            MONTH_TIMEOUT_FLOOR_SECONDS / 3600,
+            MIN_FETCH_RATE,
+        )
         async with asyncio.timeout(timeout_seconds):
             await asyncio.gather(
                 *(_one(acc, client) for acc in accessions), return_exceptions=True

--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -98,6 +98,7 @@ def month_deadline(n_accessions: int) -> float:
     """Wall-clock ceiling for fetching `n_accessions`, expressed as a rate floor."""
     return max(MONTH_TIMEOUT_FLOOR_SECONDS, n_accessions / MIN_FETCH_RATE)
 
+
 #: Fraction of a month's accessions that may fail to fetch before the month is
 #: not "done". Individual accessions do get withdrawn from GEO, so this is not
 #: zero; but 2020-06 was marked done having written 68,296 of 73,548 GSMs (7%

--- a/packages/omicidx-prefect/tests/test_geo.py
+++ b/packages/omicidx-prefect/tests/test_geo.py
@@ -66,3 +66,25 @@ def test_extract_month_refuses_to_mark_a_holed_month_done(monkeypatch, tmp_path)
 async def _completed(value):
     """`extract_month` calls these under `asyncio.run`, so stubs stay awaitable."""
     return value
+
+
+def test_month_deadline_scales_with_accession_count():
+    """A fixed wall clock is only correct for one month size (#174)."""
+    from omicidx.prefect.flows.geo import (
+        MIN_FETCH_RATE,
+        MONTH_TIMEOUT_FLOOR_SECONDS,
+        month_deadline,
+    )
+
+    # Ordinary months stay on the floor — the guard is unchanged for them.
+    assert month_deadline(46_106) == MONTH_TIMEOUT_FLOOR_SECONDS
+    assert month_deadline(62_419) == MONTH_TIMEOUT_FLOOR_SECONDS
+
+    # 2019-05 is real: 732,475 accessions, 16x its neighbours. At the old fixed
+    # 2h it could not finish, and being first in the pending list it blocked the
+    # whole backfill.
+    monster = month_deadline(732_475)
+    assert monster > MONTH_TIMEOUT_FLOOR_SECONDS
+    assert monster == 732_475 / MIN_FETCH_RATE
+    # Comfortably past the ~4.6h the month needs at measured throughput.
+    assert monster > 4.6 * 3600


### PR DESCRIPTION
Answers the "how to detect it" question left open in #174, and reports the census.

## Detection is ~185 requests, not 185 re-crawls

#174 assumed comparing a month's record count against a fresh accession count meant "a full re-crawl per month, which is most of the cost of just re-extracting". It doesn't. `esearch` with `retmax=0` returns `esearchresult.count` and zero records, and the written counts are already in each month's semaphore metadata. The whole census runs in about three minutes.

The comparison is deliberately one-sided, which is what makes it sound: partitions are keyed by **Update Date**, and an update date only moves forward. A record can leave a past window; it can never enter one. So today's count is always ≤ the count at extraction time, and `written < today` is *proof* of a hole with the deficit as a lower bound. (`written >= today` is not proof of health — it just isn't proof of loss. That asymmetry is fine, because we only need to find the short months.)

Serial, 0.5s between requests, well under the anonymous 3 req/s limit — it is safe to run while an extract is in flight, which matters given #154.

## Census: the loss tracks contention, not age

```
2005-01..2016-12   clean, every month
2017-01..2019-11   short by 1-46 records    (<=0.1%)
2019-12..2020-06   short by 284-3,476       (0.7% -> 4.7%)
```

**22 of 185 months short, ≥7,867 records missing.** 159 at-or-above, 4 (2005-01..04) predate counts-in-metadata and can't be checked this way.

The gradient is the #154 story showing up in the data. These months were extracted *most recently* — the backlog crawl was working through 2019–2020 during the stacked-run pathology — while the early years were crawled when GEO was small and the endpoint uncontended. It is not decay over time; it is load at extraction time.

## Corrects #174's headline number

"2020-06 wrote 68,296 of 73,548 GSMs — a 7% hole" compared **GSM-only writes** against the **all-entity** count. Like-for-like it is 70,072 of 73,548 — a **4.7%** hole. Still the worst month by some margin, but not 7%.

## What this implies for the repair

The 7 months at ≥0.5% hold 7,623 of the 7,867 missing records — **97% of the loss in 7 months (~2.5h)** versus 22 months (~5.5h) for the last 3%. Both are a long way from the 185-month, ~68h wholesale re-extract #174 contemplated. Repair is queued behind the 74-month backfill currently running; re-running this script afterwards is the verification.

## Second commit: the month deadline was blocking the backfill

Found by running the backfill this PR's census was meant to inform. It made **zero progress in five hours**.

`2019-05` is first in the pending list and holds **732,475 accessions** — 16x its neighbours (2019-04: 46,106, 2019-06: 44,880). A GEO-wide bulk update, verified independently via esearch count, not a pagination artefact. At the measured ~44 req/s it needs ~4.6h. `MONTH_TIMEOUT_SECONDS = 7200` killed it at 2h, tenacity retried, it died at 2h again — three times, six hours, nothing extracted, every month behind it blocked.

The #171 guard was right; its shape was wrong. A month's work is proportional to its accession count, so a fixed wall clock is only correct for one month size — and it was calibrated on a 62k month. `month_deadline()` makes it a **rate floor**: 10 req/s, preserving the ~5x headroom the fixed 2h was chosen for, at any size.

```
  46,106 accessions ->  2.00h   (unchanged — floor)
  62,419 accessions ->  2.00h   (unchanged — floor)
 732,475 accessions -> 20.35h
```

The deadline is now logged per month, so the next outlier is visible rather than inferred:

```
geo: 732475 accessions, deadline 20.3h (floor 2.0h, min 10 req/s)
```

This also revises #174'''s premise: the backlog is **not** a clean "2020-07 onward" frontier. 2019-05 has no semaphore while both neighbours do — the monster month never finished under any scheduler, Prefect or systemd. Stacked runs never got that far, so it was invisible. Revised backfill estimate: ~30h, not 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY