### PR TITLE
fix(geo): retry ReadError — it is 99% of all fetch failures (#174)

### DIFF
--- a/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
+++ b/packages/omicidx-prefect/src/omicidx/prefect/flows/geo.py
@@ -113,11 +113,20 @@ MAX_FETCH_FAILURE_RATE = 0.02
 
 
 def _is_retryable(e: BaseException) -> bool:
-    """Transport hiccups and NCBI backpressure -- not 4xx, which never heals."""
+    """Transport hiccups and NCBI backpressure -- not 4xx, which never heals.
+
+    `httpx.NetworkError`, not `httpx.ConnectError`. They are siblings, and
+    naming only the connect case silently excluded `ReadError` -- the socket
+    dying mid-response, which is precisely how NCBI drops a request under load.
+    Measured over the 6,067,977-record backfill: **530 of 534 failures were
+    ReadError**, none of them retried even once, each one landing straight in
+    the failure counter. That is the entire ~0.0-0.1% deficit the completeness
+    audit reports on nearly every month.
+    """
     if isinstance(e, httpx.HTTPStatusError):
         return e.response.status_code == 429 or 500 <= e.response.status_code < 600
     return isinstance(
-        e, httpx.RemoteProtocolError | httpx.ConnectError | httpx.TimeoutException
+        e, httpx.NetworkError | httpx.RemoteProtocolError | httpx.TimeoutException
     )
 
 

--- a/packages/omicidx-prefect/tests/test_geo.py
+++ b/packages/omicidx-prefect/tests/test_geo.py
@@ -88,3 +88,29 @@ def test_month_deadline_scales_with_accession_count():
     assert monster == 732_475 / MIN_FETCH_RATE
     # Comfortably past the ~4.6h the month needs at measured throughput.
     assert monster > 4.6 * 3600
+
+
+def test_readerror_is_retryable():
+    """ReadError is a NetworkError sibling of ConnectError, not a timeout (#174).
+
+    Naming only ConnectError excluded it, and it is how NCBI drops a request
+    under load: 530 of 534 failures across a 6M-record backfill were ReadError,
+    none retried.
+    """
+    import httpx
+    from omicidx.prefect.flows.geo import _is_retryable
+
+    req = httpx.Request("GET", "https://example.org")
+    assert _is_retryable(httpx.ReadError("socket died", request=req))
+    assert _is_retryable(httpx.ConnectError("refused", request=req))
+    assert _is_retryable(httpx.ReadTimeout("slow", request=req))
+    assert _is_retryable(httpx.RemoteProtocolError("bad frame", request=req))
+
+    # 4xx never heals, so it must still not be retried.
+    resp = httpx.Response(404, request=req)
+    assert not _is_retryable(httpx.HTTPStatusError("nf", request=req, response=resp))
+    assert _is_retryable(
+        httpx.HTTPStatusError(
+            "rate", request=req, response=httpx.Response(429, request=req)
+        )
+    )


### PR DESCRIPTION
`_is_retryable` named `httpx.ConnectError` and `httpx.TimeoutException`, which looks
exhaustive and is not: `ReadError` is a *sibling* of `ConnectError` under `NetworkError`,
not a timeout. It is the socket dying mid-response — precisely how NCBI drops a request
under load — and it was never retried even once, going straight to the failure counter.

Measured over the 6,067,977-record backfill: **530 of 534 failures were ReadError.** That
single gap is the entire ~0.0–0.1% deficit the completeness audit reports on nearly every
one of 260 months, including all 75 just extracted with the current code.

Widening to `httpx.NetworkError` covers ConnectError, ReadError, WriteError and CloseError,
and `_fetch_soft` already retries 5x with exponential jitter, so these become retries
instead of silent losses. 4xx still never retries.

Found by re-running `scripts/geo_audit.py` after the backfill: every fresh month came back
short by 1–80 records — not a re-extraction problem, a per-request one. No amount of
re-extracting would have fixed it.

Unblocks the 74-month backfill in #174; GEO's timer stays uninstalled until that backlog
is burned down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY