### PR TITLE
chore(systemd): raise ebi-biosample TimeoutStartSec to 12h for the backfill (#173)

### DIFF
--- a/systemd/omicidx-ebi-biosample-extract.service
+++ b/systemd/omicidx-ebi-biosample-extract.service
@@ -27,10 +27,12 @@ EnvironmentFile=/home/davsean/Documents/git/omicidx/.env
 ExecStart=%h/.local/bin/uv run python -m omicidx.prefect.flows.ebi_biosample run
 # RuntimeMaxSec= silently has no effect on Type=oneshot — use TimeoutStartSec=.
 # An incremental night is one day partition (seconds) plus the DuckDB rollup over
-# ~2,000 NDJSON files (minutes). 6h is sized for a backfill night, where every
+# ~2,000 NDJSON files (minutes). 12h is sized for a backfill night, where every
 # missing day since 2021-01-01 is crawled 4-wide; per-day semaphores make a
-# timeout resumable rather than wasted.
-TimeoutStartSec=21600
+# timeout resumable rather than wasted. 6h was tripping every night mid-2024
+# (#173) — a resumable kill, but it was pacing the drain at 6h/day. Ceiling is
+# the ~24h until the next fire; 12h leaves room and still ends before noon.
+TimeoutStartSec=43200
 Nice=10
 
 [Install]


### PR DESCRIPTION
`omicidx-ebi-biosample-extract` has been failing nightly with
`start operation timed out` — not an error in the crawl, the 6h `TimeoutStartSec`
ceiling. Per-day semaphores checkpoint progress, so each kill is resumable rather
than wasted, but it capped the drain at 6h/night and the crawl is still working
through 2024-02.

12h roughly doubles the nightly bite and stays well under the ~24h until the next
fire (02:00 UTC + up to 30min jitter). No `Conflicts=` change: this is a
cursor-paged HTTPS crawl, not an NCBI bulk download, so a longer window doesn't
contend with the other extracts for bandwidth. Overlapping `omicidx-downstream`
is harmless — they're decoupled by design, an in-flight extract just means those
days land in the next load cycle.

Already applied to the running unit on onclappc02 (`daemon-reload` done,
`TimeoutStartUSec=12h` confirmed, failed state cleared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSKj96vyR9LZGmRwjWkpbY